### PR TITLE
PR: Search History dropdown (Issue #30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,13 @@
           "default": false,
           "markdownDescription": "Show search results in a collapsed state by default. When enabled, file groups will be collapsed to show only match counts until expanded.",
           "order": 6
+        },
+        "rifler.searchHistory.maxEntries": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "markdownDescription": "Maximum number of recent searches kept in history (shown when clicking the magnifying glass icon).",
+          "order": 7
         }
       }
     }

--- a/src/__tests__/e2e/suite/search-history.test.ts
+++ b/src/__tests__/e2e/suite/search-history.test.ts
@@ -1,0 +1,151 @@
+import * as assert from 'assert';
+import { after, before } from 'mocha';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { testHelpers } from '../../../extension';
+
+async function waitForMessage<T = any>(webview: vscode.Webview, type: string, timeoutMs = 12000): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      disposable.dispose();
+      reject(new Error(`Timeout waiting for message ${type}`));
+    }, timeoutMs);
+
+    const disposable = webview.onDidReceiveMessage((message: any) => {
+      if (message?.type === type) {
+        clearTimeout(timer);
+        disposable.dispose();
+        resolve(message as T);
+      }
+    });
+  });
+}
+
+suite('Rifler Search History E2E', () => {
+  let workspaceRoot: string;
+  let fileA: string;
+  let fileB: string;
+
+  const tokenA = 'rifler_history_token_A_12345';
+  const tokenB = 'rifler_history_token_B_67890';
+
+  before(async () => {
+    const extension = vscode.extensions.getExtension('Ori-Roza.rifler');
+    if (extension && !extension.isActive) {
+      await extension.activate();
+    }
+
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      throw new Error('No workspace folder available');
+    }
+
+    workspaceRoot = workspaceFolder.uri.fsPath;
+
+    // Ensure deterministic UI location.
+    const config = vscode.workspace.getConfiguration('rifler');
+    await config.update('panelLocation', 'window', vscode.ConfigurationTarget.Workspace);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // Ensure persistence is enabled for this suite (we test persistence across panel reopen).
+    await config.update('persistSearchState', true, vscode.ConfigurationTarget.Workspace);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await config.update('persistenceScope', 'workspace', vscode.ConfigurationTarget.Workspace);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // Ensure default max entries is 5 (explicitly set, to avoid user machine overrides).
+    await config.update('searchHistory.maxEntries', 5, vscode.ConfigurationTarget.Workspace);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    fileA = path.join(workspaceRoot, 'rifler-history-a.ts');
+    fileB = path.join(workspaceRoot, 'rifler-history-b.ts');
+
+    fs.writeFileSync(fileA, `export const a = "${tokenA}";\n`);
+    fs.writeFileSync(fileB, `export const b = "${tokenB}";\n`);
+  });
+
+  after(async () => {
+    const config = vscode.workspace.getConfiguration('rifler');
+    await config.update('panelLocation', undefined, vscode.ConfigurationTarget.Workspace);
+    await config.update('persistSearchState', undefined, vscode.ConfigurationTarget.Workspace);
+    await config.update('persistenceScope', undefined, vscode.ConfigurationTarget.Workspace);
+    await config.update('searchHistory.maxEntries', undefined, vscode.ConfigurationTarget.Workspace);
+
+    try {
+      if (fs.existsSync(fileA)) fs.unlinkSync(fileA);
+      if (fs.existsSync(fileB)) fs.unlinkSync(fileB);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test('Selecting a history item triggers immediate search', async function () {
+    this.timeout(30000);
+
+    await vscode.commands.executeCommand('rifler._openWindowInternal');
+    await new Promise((resolve) => setTimeout(resolve, 1800));
+
+    const panel = testHelpers.getCurrentPanel();
+    assert.ok(panel, 'Panel should be open');
+
+    // Clear history deterministically.
+    const cleared = waitForMessage<{ type: string; entries: any[] }>(panel.webview, '__test_searchHistory');
+    panel.webview.postMessage({ type: '__test_clearSearchHistory' });
+    const clearedMsg = await cleared;
+    assert.ok(Array.isArray(clearedMsg.entries), 'Expected history entries array');
+    assert.strictEqual(clearedMsg.entries.length, 0, 'Expected cleared history');
+
+    // First search
+    const doneA = waitForMessage<{ type: string; results: any[] }>(panel.webview, '__test_searchCompleted');
+    panel.webview.postMessage({ type: '__test_setSearchInput', value: tokenA });
+    const msgA = await doneA;
+    assert.ok(Array.isArray(msgA.results), 'Expected results array');
+    assert.ok(msgA.results.length >= 1, 'Expected at least one result for tokenA');
+
+    // Second search
+    const doneB = waitForMessage<{ type: string; results: any[] }>(panel.webview, '__test_searchCompleted');
+    panel.webview.postMessage({ type: '__test_setSearchInput', value: tokenB });
+    const msgB = await doneB;
+    assert.ok(Array.isArray(msgB.results), 'Expected results array');
+    assert.ok(msgB.results.length >= 1, 'Expected at least one result for tokenB');
+
+    // Confirm history has both entries, newest first
+    panel.webview.postMessage({ type: '__test_getSearchHistory' });
+    const historyMsg = await waitForMessage<{ type: string; entries: Array<{ query: string }> }>(panel.webview, '__test_searchHistory');
+    assert.ok(historyMsg.entries.length >= 2, 'Expected at least 2 history entries');
+    assert.strictEqual(historyMsg.entries[0].query, tokenB, 'Expected newest query first');
+
+    // Select older entry by index and ensure it triggers a search immediately (no extra trigger)
+    const doneSelect = waitForMessage<{ type: string; results: any[] }>(panel.webview, '__test_searchCompleted');
+    panel.webview.postMessage({ type: '__test_selectSearchHistoryIndex', index: 1 });
+    const msgSelect = await doneSelect;
+    assert.ok(msgSelect.results.length >= 1, 'Expected results after selecting history item');
+
+    // Verify query input updated to tokenA
+    panel.webview.postMessage({ type: '__test_getQueryValue' });
+    const queryValue = await waitForMessage<{ type: string; value: string }>(panel.webview, '__test_queryValue');
+    assert.strictEqual(queryValue.value, tokenA);
+  });
+
+  test('History persists across panel reopen', async function () {
+    this.timeout(30000);
+
+    await vscode.commands.executeCommand('rifler._closeWindowInternal');
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    await vscode.commands.executeCommand('rifler._openWindowInternal');
+    await new Promise((resolve) => setTimeout(resolve, 1800));
+
+    const panel = testHelpers.getCurrentPanel();
+    assert.ok(panel, 'Panel should be open');
+
+    // Ensure webview has loaded persisted history
+    panel.webview.postMessage({ type: '__test_getSearchHistory' });
+    const historyMsg = await waitForMessage<{ type: string; entries: Array<{ query: string }> }>(panel.webview, '__test_searchHistory');
+    const queries = historyMsg.entries.map((e) => e.query);
+
+    assert.ok(queries.includes(tokenA), 'Expected tokenA in persisted history');
+    assert.ok(queries.includes(tokenB), 'Expected tokenB in persisted history');
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,7 +249,7 @@ export async function activate(context: vscode.ExtensionContext) {
   viewManager.setPanelManager(panelManager);
 
   // Register sidebar provider
-  const sidebarProvider = new RiflerSidebarProvider(context, {
+  const sidebarProvider = new RiflerSidebarProvider(context, stateStore, {
     viewType: RiflerSidebarProvider.sidebarViewType,
     logLabel: 'SidebarProvider'
   });
@@ -262,7 +262,7 @@ export async function activate(context: vscode.ExtensionContext) {
   viewManager.registerSidebarProvider(sidebarProvider);
 
   // Register bottom panel provider
-  const bottomProvider = new RiflerSidebarProvider(context, {
+  const bottomProvider = new RiflerSidebarProvider(context, stateStore, {
     viewType: RiflerSidebarProvider.bottomViewType,
     logLabel: 'BottomProvider'
   });

--- a/src/messaging/registerCommonHandlers.ts
+++ b/src/messaging/registerCommonHandlers.ts
@@ -34,7 +34,30 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
       msg.modulePath
     );
     console.log('[Rifler] Search returned', results.length, 'results');
+
+    if (deps.stateStore) {
+      deps.stateStore.recordSearch({
+        query: msg.query,
+        scope: msg.scope,
+        directoryPath: msg.directoryPath,
+        modulePath: msg.modulePath,
+        options: {
+          matchCase: !!msg.options.matchCase,
+          wholeWord: !!msg.options.wholeWord,
+          useRegex: !!msg.options.useRegex,
+          fileMask: msg.options.fileMask || ''
+        }
+      });
+      deps.postMessage({ type: 'searchHistory', entries: deps.stateStore.getSearchHistory() });
+    }
+
     deps.postMessage({ type: 'searchResults', results, maxResults: 10000 });
+  });
+
+  handler.registerHandler('__test_clearSearchHistory', async () => {
+    if (!deps.stateStore) return;
+    deps.stateStore.clearSearchHistory();
+    deps.postMessage({ type: 'searchHistory', entries: deps.stateStore.getSearchHistory() });
   });
 
   handler.registerHandler('openLocation', async (message) => {

--- a/src/services/PanelManager.ts
+++ b/src/services/PanelManager.ts
@@ -300,6 +300,12 @@ export class PanelManager {
       type: 'restorePreviewPanelState',
       collapsed: this.stateStore.getPreviewPanelCollapsed()
     });
+
+    // Send search history (for magnifying-glass dropdown)
+    this.currentPanel.webview.postMessage({
+      type: 'searchHistory',
+      entries: this.stateStore.getSearchHistory()
+    });
   }
 }
 

--- a/src/state/StateStore.ts
+++ b/src/state/StateStore.ts
@@ -1,6 +1,21 @@
 import * as vscode from 'vscode';
 import { MinimizeMessage } from '../messaging/types';
 
+export interface SearchHistoryEntry {
+  query: string;
+  scope: string;
+  directoryPath?: string;
+  modulePath?: string;
+  filePath?: string;
+  options: {
+    matchCase: boolean;
+    wholeWord: boolean;
+    useRegex: boolean;
+    fileMask: string;
+  };
+  ts: number;
+}
+
 /**
  * Lightweight shared state holder for sidebar visibility, minimized flag, and saved search state.
  * Panel ownership (panel/status bar) remains in PanelManager.
@@ -12,6 +27,7 @@ export class StateStore {
   private savedState: MinimizeMessage['state'] | undefined;
   private previewPanelCollapsed = false;
   private resultsShowCollapsed = false;
+  private searchHistory: SearchHistoryEntry[] = [];
   private visibilityCallbacks: Array<(visible: boolean) => void> = [];
   private bottomVisibilityCallbacks: Array<(visible: boolean) => void> = [];
 
@@ -29,9 +45,49 @@ export class StateStore {
       // Load preview panel collapsed state - default to expanded (false)
       const previewCollapsed = store.get<boolean>('rifler.previewPanelCollapsed', false);
       this.previewPanelCollapsed = previewCollapsed || false; // Ensure it's false if undefined
+
+      // Load search history - default empty
+      const history = store.get<SearchHistoryEntry[]>('rifler.searchHistory', []);
+      this.searchHistory = Array.isArray(history) ? history : [];
+
+      // Normalize + de-dupe any persisted history (self-healing), keeping the most recent per query.
+      const normalizeKey = (q: string): string => (q || '').trim().toLowerCase();
+      const normalizedHistory = this.searchHistory
+        .map((h) => {
+          const query = (h?.query || '').trim();
+          return {
+            query,
+            scope: (h?.scope || 'project') as string,
+            directoryPath: h?.directoryPath,
+            modulePath: h?.modulePath,
+            filePath: h?.filePath,
+            options: {
+              matchCase: !!h?.options?.matchCase,
+              wholeWord: !!h?.options?.wholeWord,
+              useRegex: !!h?.options?.useRegex,
+              fileMask: h?.options?.fileMask || ''
+            },
+            ts: typeof h?.ts === 'number' ? h.ts : 0
+          } satisfies SearchHistoryEntry;
+        })
+        .filter((h) => !!h.query);
+
+      normalizedHistory.sort((a, b) => (b.ts || 0) - (a.ts || 0));
+      const seen = new Set<string>();
+      const deduped: SearchHistoryEntry[] = [];
+      for (const h of normalizedHistory) {
+        const key = normalizeKey(h.query);
+        if (!key || seen.has(key)) continue;
+        seen.add(key);
+        deduped.push(h);
+      }
+
+      this.searchHistory = deduped;
+      store.update('rifler.searchHistory', this.searchHistory);
     } else {
       this.savedState = undefined;
       this.previewPanelCollapsed = false;
+      this.searchHistory = [];
     }
 
     // Load results show collapsed setting from configuration
@@ -99,6 +155,51 @@ export class StateStore {
     const store = scope === 'global' ? this.context.globalState : this.context.workspaceState;
     if (persist) {
       store.update('rifler.previewPanelCollapsed', collapsed);
+    }
+  }
+
+  getSearchHistory(): SearchHistoryEntry[] {
+    return [...this.searchHistory];
+  }
+
+  clearSearchHistory(): void {
+    this.searchHistory = [];
+    const cfg = vscode.workspace.getConfiguration('rifler');
+    const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
+    const persist = cfg.get<boolean>('persistSearchState', true) && scope !== 'off';
+    const store = scope === 'global' ? this.context.globalState : this.context.workspaceState;
+    if (persist) {
+      store.update('rifler.searchHistory', this.searchHistory);
+    }
+  }
+
+  recordSearch(entry: Omit<SearchHistoryEntry, 'ts'>): void {
+    const normalizeKey = (q: string): string => (q || '').trim().toLowerCase();
+    const normalized: SearchHistoryEntry = {
+      ...entry,
+      query: (entry.query || '').trim(),
+      ts: Date.now()
+    };
+
+    if (!normalized.query) {
+      return;
+    }
+
+    const cfg = vscode.workspace.getConfiguration('rifler');
+    const maxEntriesRaw = cfg.get<number>('searchHistory.maxEntries', 5);
+    const maxEntries = Math.max(1, Math.floor(Number.isFinite(maxEntriesRaw) ? maxEntriesRaw : 5));
+
+    // Treat the query text as the unique key (case-insensitive) so the same query never appears twice.
+    // Keep the most recent entry's scope/options/paths.
+    const normalizedKey = normalizeKey(normalized.query);
+    const withoutDupes = this.searchHistory.filter((h) => normalizeKey(h.query) !== normalizedKey);
+    this.searchHistory = [normalized, ...withoutDupes].slice(0, maxEntries);
+
+    const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
+    const persist = cfg.get<boolean>('persistSearchState', true) && scope !== 'off';
+    const store = scope === 'global' ? this.context.globalState : this.context.workspaceState;
+    if (persist) {
+      store.update('rifler.searchHistory', this.searchHistory);
     }
   }
 

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -9,8 +9,12 @@
 <section class="search-section">
   <div class="search-box">
     <div class="search-input-group">
-      <span class="material-symbols-outlined search-icon">search</span>
+      <button type="button" class="search-history-btn" id="search-history-btn" title="Search history" aria-label="Search history">
+        <span class="material-symbols-outlined search-icon" aria-hidden="true">search</span>
+        <span class="material-symbols-outlined search-history-caret" aria-hidden="true">arrow_drop_down</span>
+      </button>
       <input type="text" id="query" class="search-input" placeholder="Search..." autofocus />
+      <div class="search-history-menu" id="search-history-menu"></div>
       <div id="query-validation-message" class="validation-message"></div>
       <div class="search-options">
         <button type="button" class="option-btn" id="match-case" title="Match Case (Alt+C)" data-option="case">

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -347,6 +347,42 @@ body.loaded {
   position: relative;
 }
 
+.search-history-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.1s;
+}
+
+.search-history-btn:hover {
+  background-color: var(--rifler-list-hover);
+}
+
+.search-history-btn:hover .material-symbols-outlined {
+  color: var(--rifler-fg);
+  opacity: 1;
+}
+
+.search-history-caret {
+  font-size: 18px;
+  color: var(--rifler-fg-muted);
+  opacity: 0.6;
+  margin-left: -4px;
+}
+
+.search-history-btn:focus-visible {
+  outline: 1px solid var(--rifler-focus-border);
+  outline-offset: 2px;
+}
+
 .search-input::placeholder {
   color: var(--rifler-input-placeholder);
   opacity: 0.7;
@@ -820,7 +856,8 @@ body.loaded {
 .search-controls .more-actions-btn {
   display: none;
 }
-.more-actions-menu {
+.more-actions-menu,
+.search-history-menu {
   position: absolute;
   right: 0;
   top: calc(100% + 6px);
@@ -834,12 +871,20 @@ body.loaded {
   max-width: calc(100vw - 16px);
   z-index: 50;
 }
-.more-actions-menu.open {
+.search-history-menu {
+  right: auto;
+  left: 0;
+  min-width: 220px;
+}
+
+.more-actions-menu.open,
+.search-history-menu.open {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.more-actions-menu button {
+.more-actions-menu button,
+.search-history-menu button {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -852,14 +897,17 @@ body.loaded {
   text-align: left;
   transition: background-color 0.12s;
 }
-.more-actions-menu button span:last-child {
+.more-actions-menu button span:last-child,
+.search-history-menu button span:last-child {
   font-size: 12px;
   line-height: 1.2;
 }
-.more-actions-menu button:hover {
+.more-actions-menu button:hover,
+.search-history-menu button:hover {
   background: var(--rifler-list-hover);
 }
-.more-actions-menu .material-symbols-outlined {
+.more-actions-menu .material-symbols-outlined,
+.search-history-menu .material-symbols-outlined {
   font-size: 18px;
   opacity: 0.8;
 }


### PR DESCRIPTION
Closes/addresses #30 

### Summary
Adds a persisted **Search History** dropdown in the webview, opened via the **Search dropdown icon** (replacing the magnifying-glass). Selecting a history item **immediately runs the search**. History is **deduped** and **limited to a configurable max** (default **5**).

### User-facing changes
- Clicking the **search dropdown icon** opens the **Search history** list.
- Hover:
  - button uses the same “shine”/hover styling as other toolbar buttons
  - tooltip text: **“Search history”**
- Clicking a history entry instantly re-runs that search.

### Behavior details
- History is stored using the existing persistence scope (workspace/global).
- Max entries is configurable via setting: `rifler.searchHistory.maxEntries` (default **5**; `0` disables if implemented that way).
- **No duplicates**: dedupe is **case-insensitive** and keeps the **newest** entry (self-heals legacy duplicates on load).

### Tests
- Added/updated unit tests for:
  - trim to max entries (default 5)
  - case-insensitive dedupe (keeps newest)
  - clearing history persists `[]`
- Added e2e coverage for:
  - dropdown opens from the search icon
  - selecting an entry triggers an immediate search
  - persisted history behavior

### Manual verification
1. Run a few searches (5+).
2. Click the search dropdown icon → shows recent terms (max 5).
3. Click an entry → search starts immediately.
4. Repeat a prior term with different options → history shows only one entry for that term (newest wins).
5. Hover icon → “shine” + tooltip “Search history”.