### PR TITLE
Show keyboard hint in sidebar/bottom view title

### DIFF
--- a/src/__tests__/e2e/suite/title-hint.test.ts
+++ b/src/__tests__/e2e/suite/title-hint.test.ts
@@ -85,18 +85,18 @@ suite('Title Hint E2E Tests', () => {
       // Hint #1
       await cleanUi();
       await setRiflerConfig('openKeybindingHint', 'cmd+alt+f');
-      await assertSidebarTitle('Search (cmd+alt+f)');
+      await assertSidebarTitle('(CMD+ALT+F)');
       await assertTabTitle('Rifler Search (cmd+alt+f)');
       await cleanUi();
-      await assertBottomTitle('Search (cmd+alt+f)');
+      await assertBottomTitle('(CMD+ALT+F)');
 
       // Hint #2
       await cleanUi();
       await setRiflerConfig('openKeybindingHint', 'ctrl+shift+g');
-      await assertSidebarTitle('Search (ctrl+shift+g)');
+      await assertSidebarTitle('(CTRL+SHIFT+G)');
       await assertTabTitle('Rifler Search (ctrl+shift+g)');
       await cleanUi();
-      await assertBottomTitle('Search (ctrl+shift+g)');
+      await assertBottomTitle('(CTRL+SHIFT+G)');
     } finally {
       // Cleanup: restore pre-test workspace settings (avoid impacting later E2E tests)
       await setRiflerConfig('panelLocation', originalPanelLocation);

--- a/src/__tests__/sidebarProvider.test.ts
+++ b/src/__tests__/sidebarProvider.test.ts
@@ -43,7 +43,7 @@ describe('RiflerSidebarProvider - current directory default', () => {
     expect(currentDirMsg.directory).toBe(workspacePath);
   });
 
-  test('sets view title to Search (<hint>)', () => {
+  test('sets view title to hint only', () => {
     (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
       inspect: jest.fn(() => ({ globalValue: 'cmd+alt+f' })),
       get: jest.fn((_key: string, defaultValue?: any) => defaultValue)
@@ -56,9 +56,10 @@ describe('RiflerSidebarProvider - current directory default', () => {
       globalState: { update: jest.fn(), get: jest.fn() }
     } as any);
 
-    (provider as any)._view = { title: '' } as any;
+    (provider as any)._view = { title: '', description: '' } as any;
     (provider as any)._updateViewTitle();
 
-    expect((provider as any)._view.title).toBe('Search (cmd+alt+f)');
+    expect((provider as any)._view.title).toBe('(CMD+ALT+F)');
+    expect((provider as any)._view.description).toBe('');
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -508,7 +508,9 @@ export const testHelpers = {
   getCurrentPanel: () => panelManager?.panel,
   getStateStore: () => stateStore,
   getSidebarTitle: () => sidebarProviderRef?.__test_getViewTitle(),
-  getBottomTitle: () => bottomProviderRef?.__test_getViewTitle()
+  getSidebarDescription: () => sidebarProviderRef?.__test_getViewDescription(),
+  getBottomTitle: () => bottomProviderRef?.__test_getViewTitle(),
+  getBottomDescription: () => bottomProviderRef?.__test_getViewDescription()
 };
 
 // Re-export messaging types for backward compatibility with tests

--- a/src/sidebar/SidebarProvider.ts
+++ b/src/sidebar/SidebarProvider.ts
@@ -198,11 +198,20 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
     if (!this._view) return;
     const cfg = vscode.workspace.getConfiguration('rifler');
     const hint = getOpenKeybindingHint(cfg).trim();
-    this._view.title = hint ? `Search (${hint})` : 'Search';
+    const displayHint = hint ? `(${hint.toUpperCase()})` : '';
+
+    // VS Code renders contributed view headers as: "<Container Title>: <View Title>".
+    // We can't remove the colon, but we can remove the redundant "Search" by using only the hint.
+    this._view.title = displayHint;
+    this._view.description = '';
   }
 
   public __test_getViewTitle(): string | undefined {
     return this._view?.title;
+  }
+
+  public __test_getViewDescription(): string | undefined {
+    return this._view?.description;
   }
 
   private async _handleMessage(message: { type: string; [key: string]: unknown }): Promise<void> {


### PR DESCRIPTION
- Display hint as (CMD+ALT+F) in view title (uppercased)
- Avoid duplicated 'Search' text in header
- Add test helpers for sidebar/bottom title assertions
- Update unit + E2E tests for new title behavior
- Fix flaky E2E test in sidebar-integration