### PR TITLE
Fix HTML sanitization: add missing closing '>' to span tag attributes

### DIFF
--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -4748,7 +4748,7 @@ console.log('[Rifler] Webview script starting...');
       if (classMatch) {
         const classes = classMatch[1].split(' ').filter(function(c) { return c.startsWith('hljs-'); });
         if (classes.length > 0) {
-          return '<span class="' + escapeHtml(classes.join(' ')) + '"';
+          return '<span class="' + escapeHtml(classes.join(' ')) + '">';
         }
       }
       return '<span>';


### PR DESCRIPTION
This fixes a bug where highlighted match text was being truncated in search results. The sanitizeHighlightedHtml function was missing the closing '>' character when reconstructing span tags, producing malformed HTML like '<span class="hljs-keyword"import</span>' instead of '<span class="hljs-keyword">import</span>'. The browser would then treat the text content as unclosed tag attributes, rendering only short non-highlighted fragments visible.

Example: searching for 'loginandemail' in profile.js now correctly shows 'import LoginAndEmail from' instead of just '.' and ':,'.