### PR TITLE
fix: smooth responsive layout transitions and sidebar narrow mode

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -46,6 +46,21 @@
         <span class="material-symbols-outlined">arrow_drop_down</span>
       </button>
       <div class="more-actions-menu" id="more-actions-menu">
+        <div class="menu-filter-row">
+          <button class="menu-filter-item" data-action="toggle-match-case" title="Match Case">
+            <span class="material-symbols-outlined">format_size</span>
+          </button>
+          <button class="menu-filter-item" data-action="toggle-whole-word" title="Match Whole Word">
+            <span class="material-symbols-outlined">match_word</span>
+          </button>
+          <button class="menu-filter-item" data-action="toggle-regex" title="Use Regular Expression">
+            <span class="material-symbols-outlined">regular_expression</span>
+          </button>
+          <button class="menu-filter-item" data-action="toggle-lsp" title="Usage-Aware Search (LSP)">
+            <span class="material-symbols-outlined">device_hub</span>
+          </button>
+        </div>
+        <div class="menu-separator"></div>
         <button data-action="toggle-replace">
           <span class="material-symbols-outlined">swap_horiz</span>
           <span>Toggle Replace</span>

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -264,11 +264,14 @@ console.log('[Rifler] Webview script starting...');
     const width = document.body.clientWidth;
     
     // Remove all layout classes
-    document.body.classList.remove('narrow-layout', 'normal-layout', 'wide-layout');
+    document.body.classList.remove('narrow-layout', 'normal-layout', 'wide-layout', 'ultra-narrow-layout');
     
     // Apply appropriate class based on width
     if (width < 350) {
       document.body.classList.add('narrow-layout');
+      if (width < 250) {
+        document.body.classList.add('ultra-narrow-layout');
+      }
       console.log('[Rifler] Applied narrow-layout for width:', width);
     } else if (width >= 350 && width <= 600) {
       document.body.classList.add('normal-layout');
@@ -282,21 +285,23 @@ console.log('[Rifler] Webview script starting...');
     // so it stays inside the main search textbox.
     try {
       const isNarrow = document.body.classList.contains('narrow-layout');
+      const needsOverflow = isNarrow;
+
       if (searchOverflow && searchControls && moreActionsBtn && moreActionsMenu) {
         const alreadyInOverflow = searchOverflow.contains(moreActionsBtn);
-        if (isNarrow && !alreadyInOverflow) {
+        if (needsOverflow && !alreadyInOverflow) {
           moreActionsMenu.classList.remove('open');
           searchOverflow.appendChild(moreActionsBtn);
           searchOverflow.appendChild(moreActionsMenu);
           document.body.classList.add('overflow-in-input');
-        } else if (!isNarrow && alreadyInOverflow) {
+        } else if (!needsOverflow && alreadyInOverflow) {
           moreActionsMenu.classList.remove('open');
           searchControls.appendChild(moreActionsBtn);
           searchControls.appendChild(moreActionsMenu);
           document.body.classList.remove('overflow-in-input');
         } else {
           // Keep class in sync even if the nodes are already in the right spot.
-          document.body.classList.toggle('overflow-in-input', isNarrow && alreadyInOverflow);
+          document.body.classList.toggle('overflow-in-input', needsOverflow && alreadyInOverflow);
         }
       }
     } catch {
@@ -338,6 +343,20 @@ console.log('[Rifler] Webview script starting...');
     if (includeCommentsToggle) includeCommentsToggle.classList.toggle('active', state.options.includeComments);
     if (includeStringsToggle) includeStringsToggle.classList.toggle('active', state.options.includeStrings);
     if (useLspToggle) useLspToggle.classList.toggle('active', state.searchMode === 'lsp');
+  }
+
+  function syncMoreActionsFilterState() {
+    if (!moreActionsMenu) return;
+    const map = {
+      'toggle-match-case': state.options.matchCase,
+      'toggle-whole-word': state.options.wholeWord,
+      'toggle-regex': state.options.useRegex,
+      'toggle-lsp': state.searchMode === 'lsp'
+    };
+    for (const [action, active] of Object.entries(map)) {
+      const btn = moreActionsMenu.querySelector('[data-action="' + action + '"]');
+      if (btn) btn.classList.toggle('active', !!active);
+    }
   }
 
   function applyContextDefaults() {
@@ -665,6 +684,7 @@ console.log('[Rifler] Webview script starting...');
         if (searchHistoryMenu) {
           searchHistoryMenu.classList.remove('open');
         }
+      syncMoreActionsFilterState();
       moreActionsMenu.classList.toggle('open');
     });
 
@@ -682,6 +702,22 @@ console.log('[Rifler] Webview script starting...');
           break;
         case 'clear-search':
           if (clearSearchBtn) clearSearchBtn.click();
+          break;
+        case 'toggle-match-case':
+          if (matchCaseToggle) matchCaseToggle.click();
+          syncMoreActionsFilterState();
+          break;
+        case 'toggle-whole-word':
+          if (wholeWordToggle) wholeWordToggle.click();
+          syncMoreActionsFilterState();
+          break;
+        case 'toggle-regex':
+          if (useRegexToggle) useRegexToggle.click();
+          syncMoreActionsFilterState();
+          break;
+        case 'toggle-lsp':
+          if (useLspToggle) useLspToggle.click();
+          syncMoreActionsFilterState();
           break;
       }
     });

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -48,13 +48,16 @@ body {
   font-size: var(--rifler-font-size);
   color: var(--rifler-fg);
   background-color: var(--rifler-bg);
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  min-width: 300px;
+  min-width: 0;
   opacity: 0;
   transition: opacity 0.15s ease-in;
+}
+html {
+  height: 100%;
 }
 
 body.loaded {
@@ -293,8 +296,10 @@ body.loaded {
   flex-direction: column;
   gap: 8px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  position: relative;
   z-index: 10;
   overflow: visible;
+  max-width: 100%;
 }
 
 /* ===== Search Box Row ===== */
@@ -303,6 +308,9 @@ body.loaded {
   gap: 8px;
   align-items: center;
   position: relative;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .search-input-group {
@@ -316,9 +324,12 @@ body.loaded {
   border: 1px solid var(--rifler-input-border);
   border-radius: 6px;
   padding: 6px 10px;
-  transition: all 0.15s;
+  transition: border-color 0.15s, box-shadow 0.15s;
   position: relative;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .search-input-group:focus-within {
@@ -373,6 +384,7 @@ body.loaded {
   cursor: pointer;
   border-radius: 6px;
   transition: all 0.1s;
+  flex-shrink: 0;
 }
 
 .search-history-btn:hover {
@@ -406,6 +418,7 @@ body.loaded {
   gap: 2px;
   flex-shrink: 0;
   margin-left: auto;
+  transition: gap 0.15s ease;
 }
 
 .multiline-btn {
@@ -429,11 +442,28 @@ body.loaded {
   display: none;
 }
 
+/* When the arrow-down button is inside the search-overflow (relocated by JS),
+   always show it — regardless of layout class */
+.search-overflow:has(.more-actions-btn) {
+  display: inline-flex !important;
+  align-items: center;
+  flex-shrink: 0;
+  animation: fadeIn 0.15s ease;
+}
+.search-overflow .more-actions-btn {
+  display: inline-flex !important;
+  width: 24px;
+  height: 28px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
 .search-controls {
   display: flex;
   gap: 2px;
   flex-shrink: 0;
   align-items: center;
+  transition: gap 0.15s ease, width 0.15s ease, opacity 0.15s ease;
 }
 
 .option-btn {
@@ -451,8 +481,9 @@ body.loaded {
   border: 1px solid transparent;
   border-radius: 2px; /* rounded-sm */
   cursor: pointer;
-  transition: all 0.1s;
+  transition: opacity 0.15s ease, width 0.15s ease, padding 0.15s ease, background-color 0.1s, color 0.1s;
   user-select: none;
+  overflow: hidden;
 }
 
 .context-text-icon {
@@ -784,7 +815,8 @@ select.path-input option {
   color: var(--rifler-fg-muted);
   cursor: pointer;
   border-radius: 6px;
-  transition: all 0.1s;
+  transition: opacity 0.15s ease, width 0.15s ease, background-color 0.1s, color 0.1s;
+  overflow: hidden;
 }
 
 .icon-btn:hover {
@@ -844,6 +876,11 @@ select.path-input option {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 /* ===== Results Summary Bar ===== */
@@ -1056,6 +1093,58 @@ select.path-input option {
 .search-history-menu .material-symbols-outlined {
   font-size: 18px;
   opacity: 0.8;
+}
+
+/* Menu filter toggle items – compact icon-only row */
+.more-actions-menu .menu-filter-row {
+  display: none;
+  gap: 2px;
+  padding: 2px 4px;
+}
+body.narrow-layout .more-actions-menu .menu-filter-row {
+  display: flex;
+}
+.more-actions-menu .menu-filter-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  gap: 0;
+  border-radius: 4px;
+  position: relative;
+}
+.more-actions-menu .menu-filter-item .menu-filter-label {
+  display: none;
+}
+.more-actions-menu .menu-filter-item .menu-check {
+  display: none;
+}
+.more-actions-menu .menu-filter-item .material-symbols-outlined {
+  font-size: 18px;
+  opacity: 0.6;
+}
+.more-actions-menu .menu-filter-item.active {
+  background: var(--rifler-list-hover);
+  color: var(--rifler-primary);
+}
+.more-actions-menu .menu-filter-item.active .material-symbols-outlined {
+  opacity: 1;
+  color: var(--rifler-primary);
+}
+.more-actions-menu .menu-separator {
+  height: 1px;
+  background: var(--rifler-border);
+  margin: 2px 4px;
+}
+
+/* Hide filter row & separator in dropdown when inline buttons are visible */
+.more-actions-menu .menu-separator {
+  display: none;
+}
+body.narrow-layout .more-actions-menu .menu-separator {
+  display: block;
 }
 
 .search-history-menu .clear-history-btn {
@@ -2134,24 +2223,16 @@ select.path-input option {
 /* ===== Responsive Layouts (Issue #98) ===== */
 /* Narrow layout for sidebar use (< 350px) */
 body.narrow-layout .search-section {
-  padding: 4px 6px;
+  padding: 6px;
   gap: 6px;
 }
 
 body.narrow-layout .search-box {
-  flex-direction: column;
-  align-items: stretch;
   gap: 4px;
 }
 
 body.narrow-layout .search-input-group {
-  padding: 4px 6px;
   gap: 4px;
-  width: 100%;
-}
-
-body.narrow-layout .search-input {
-  padding: 4px 0;
 }
 
 body.narrow-layout .search-controls {
@@ -2162,25 +2243,46 @@ body.narrow-layout .search-controls {
 
 /* When we relocate the overflow button into the input group, hide the empty controls row */
 body.narrow-layout.overflow-in-input .search-controls {
-  display: none;
+  width: 0;
+  overflow: hidden;
+  gap: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
 body.narrow-layout .search-overflow {
   display: inline-flex;
   align-items: center;
   position: static;
+  flex-shrink: 0;
+}
+
+body.narrow-layout .search-options .option-btn {
+  width: 0;
+  opacity: 0;
+  pointer-events: none;
+  border-width: 0;
+}
+
+body.narrow-layout .search-options {
+  flex-shrink: 0;
+  overflow: visible;
+  min-width: 26px;
+  gap: 0;
 }
 
 body.narrow-layout .search-overflow .more-actions-btn {
-  display: inline-flex;
+  display: inline-flex !important;
   width: 24px;
   height: 28px;
   border-radius: 2px;
+  flex-shrink: 0;
 }
 
 body.narrow-layout .search-overflow .more-actions-menu {
   top: calc(100% + 6px);
   right: 0;
+  min-width: min(200px, calc(100vw - 16px));
 }
 
 body.narrow-layout .icon-btn {
@@ -2195,7 +2297,9 @@ body.narrow-layout .icon-btn {
 
 /* In narrow layout, hide individual controls and show the overflow menu */
 body.narrow-layout .search-controls .icon-btn:not(.more-actions-btn) {
-  display: none;
+  width: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 body.narrow-layout .search-controls .more-actions-btn {
   display: inline-flex;
@@ -2221,12 +2325,20 @@ body.narrow-layout .results-summary-bar {
 
 body.narrow-layout .results-count-text {
   font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 body.narrow-layout .collapse-all-btn {
   padding: 3px 6px;
   font-size: 11px;
   gap: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
 }
 
 body.narrow-layout .result-file-header {
@@ -2241,6 +2353,9 @@ body.narrow-layout .file-name {
 
 body.narrow-layout .file-path {
   font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 body.narrow-layout .match-count {
@@ -2284,6 +2399,7 @@ body.narrow-layout .preview-filepath {
 body.narrow-layout .replace-field-row {
   padding: 4px 6px;
   gap: 4px;
+  flex-wrap: wrap;
 }
 
 body.narrow-layout .replace-input {
@@ -2298,6 +2414,73 @@ body.narrow-layout .replace-actions {
 body.narrow-layout .replace-actions button {
   padding: 3px 8px;
   font-size: 11px;
+}
+
+body.narrow-layout .empty-state {
+  font-size: 11px;
+  padding: 8px;
+  word-break: break-word;
+}
+
+body.narrow-layout .results-summary-bar {
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ===== Ultra-narrow layout (< 250px) ===== */
+body.ultra-narrow-layout .search-history-btn .search-history-caret {
+  display: none;
+}
+
+body.ultra-narrow-layout .search-history-btn {
+  padding: 2px;
+  min-width: 22px;
+}
+
+body.ultra-narrow-layout .search-input-group {
+  gap: 2px;
+  min-width: 0;
+}
+
+body.ultra-narrow-layout .search-section {
+  gap: 4px;
+}
+
+body.ultra-narrow-layout .results-count-text {
+  font-size: 10px;
+}
+
+body.ultra-narrow-layout .result-file-header {
+  padding: 3px 6px;
+  gap: 4px;
+  min-height: 28px;
+}
+
+body.ultra-narrow-layout .result-item {
+  padding: 2px 4px 2px 16px;
+}
+
+body.ultra-narrow-layout .file-name {
+  font-size: 11px;
+}
+
+body.ultra-narrow-layout .line-number {
+  min-width: 24px;
+  font-size: 9px;
+}
+
+body.ultra-narrow-layout .replace-field-row {
+  padding: 3px 4px;
+}
+
+body.ultra-narrow-layout .filters-container {
+  padding: 3px;
+  gap: 3px;
+}
+
+body.ultra-narrow-layout .lsp-mode-row {
+  padding: 3px 4px;
+  gap: 4px;
 }
 
 /* Normal layout (350px - 600px) - default styles apply */


### PR DESCRIPTION
- Fix search-section z-index: add position: relative so z-index: 10 actually layers above results-summary-bar, preventing overlap when sidebar is narrowed

- Prevent textbox height changes during narrowing:
  - Keep search-box in row layout at all widths (remove flex-direction: column)
  - Don't change padding on search-input-group or search-section in narrow mode
  - Only change gap/min-width which don't affect layout dimensions
  - Search controls hide via opacity/width instead of display: none

- Compact filter dropdown buttons:
  - Display filter toggles as icon-only in horizontal row
  - Only visible in narrow layout dropdown (not in normal layout menu)

- Smooth transitions between compact and regular modes:
  - Option buttons fade and collapse width over 150ms instead of snapping
  - Search controls smoothly collapse gap/width/opacity
  - Overflow dropdown fades in with animation
  - All filter buttons use overflow: hidden to clip during collapse

This fixes the glitch where the search textboThis fixes the glitch where the search textboThis fixes the glitch where thyout mode transitions feel natural instead of abrupt.