### PR TITLE
Document QuickPick overflow behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## Features
 
 - **Dynamic Search** - Results appear as you type (no Find button needed)
-- **QuickPick Search** - A keyboard-first QuickPick search mode with live results and inline filters
+- **QuickPick Search** - A keyboard-first QuickPick search mode with live results, inline filters, and a "Show all results in Rifler" overflow for larger queries
 - **Search From Selection** - Select text in the editor, then open Rifler and it will be used as the initial search query
 - **Fresh State** - Automatically clears search results and state when switching workspaces
 - **High Performance**
@@ -122,7 +122,8 @@ Use **Rifler: Search in Files (QuickPick)** for a lightweight, keyboard-first se
 1. Press `Cmd+Alt+P` (Mac) or `Ctrl+Alt+P` (Windows/Linux)
 2. Type your query (results appear as you type)
 3. Toggle **Match Case**, **Whole Word**, and **Regex** using the QuickPick buttons
-4. Press `Enter` to open the selected result in the editor
+4. If results hit the cap, select **Show all results in Rifler** to open the full panel with the same query
+5. Press `Enter` to open the selected result in the editor
 
 ### QuickPick Replace
 
@@ -131,7 +132,8 @@ Use **Rifler: Replace in Files (QuickPick)** for a fast replace flow:
 1. Run **Rifler: Replace in Files (QuickPick)** from the Command Palette
 2. Type your query (results appear as you type)
 3. Toggle **Match Case**, **Whole Word**, and **Regex** using the QuickPick buttons
-4. Select a match, enter replacement text, then choose **Replace One** or **Replace All**
+4. If results hit the cap, select **Show all results in Rifler** to open the full panel in replace mode
+5. Select a match, enter replacement text, then choose **Replace One** or **Replace All**
 
 ### Usage-Aware Search (LSP)
 

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
       <div class="feature-card">
         <div class="feature-icon">⚡</div>
         <h3>QuickPick Search</h3>
-        <p>Launch a lightweight, keyboard-first search via QuickPick. Use <strong>Cmd+Alt+P</strong> (Mac) / <strong>Ctrl+Alt+P</strong> (Windows/Linux) and toggle Match Case, Whole Word, or Regex inline.</p>
+        <p>Launch a lightweight, keyboard-first search via QuickPick. Use <strong>Cmd+Alt+P</strong> (Mac) / <strong>Ctrl+Alt+P</strong> (Windows/Linux) and toggle Match Case, Whole Word, or Regex inline. Hit the cap and jump to full Rifler with “Show all results in Rifler” (QuickPick Replace opens in replace mode).</p>
       </div>
 
       <div class="feature-card">


### PR DESCRIPTION
## Summary
- document the QuickPick overflow entry that opens the full Rifler panel
- note that QuickPick Replace overflow opens Rifler in replace mode