### PR TITLE
Add search timeouts and telemetry flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rifler",
   "icon": "assets/icon.jpeg",
   "description": "Fast file search with dynamic results, regex, file mask, and full preview",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "publisher": "Ori-Roza",
   "repository": "https://github.com/ori-roza/rifler",
   "engines": {

--- a/src/__tests__/e2e/suite/multiline-search.test.ts
+++ b/src/__tests__/e2e/suite/multiline-search.test.ts
@@ -84,11 +84,11 @@ Final section.
     log('\n🔹 Testing multiline search with empty line pattern');
     log('   🔍 Query: "npm test\\n\\n# Run"');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'npm test\n\n# Run',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     assert.ok(results.length >= 1, 'Should find multiline pattern with empty line');
@@ -101,11 +101,11 @@ Final section.
     log('\n🔹 Testing multiline search without empty line');
     log('   🔍 Query: "function hello() {\\n  console.log"');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'function hello() {\n  console.log',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     assert.ok(results.length >= 1, 'Should find multiline pattern without empty line');
@@ -118,11 +118,11 @@ Final section.
     log('\n🔹 Testing multiple multiline matches');
     log('   🔍 Query: "test\\n\\n#" (pattern appears twice)');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'test\n\n#',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     // The pattern "test\n\n#" appears twice in our test file
@@ -136,11 +136,11 @@ Final section.
     log('\n🔹 Testing multiline regex search');
     log('   🔍 Query: "npm test\\n\\n# .*" (regex)');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'npm test\n\n# .*',
       'project',
       { matchCase: false, wholeWord: false, useRegex: true, fileMask: '', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     assert.ok(results.length >= 1, 'Should find multiline regex pattern');
@@ -153,13 +153,13 @@ Final section.
     log('\n🔹 Testing line numbers in multiline results');
     log('   🔍 Query: "npm test\\n\\n# Run"');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'npm test\n\n# Run',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '', multiline: true },
       undefined,
       undefined
-    );
+    )).results;
 
     if (results.length > 0) {
       log(`   📊 First match at line ${results[0].line}`);
@@ -177,11 +177,11 @@ Final section.
     log('\n🔹 Testing non-matching multiline pattern');
     log('   🔍 Query: "npm test\\n\\n\\n# Run" (extra empty line)');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'npm test\n\n\n# Run',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     assert.strictEqual(results.length, 0, 'Should not find pattern with incorrect line count');
@@ -196,11 +196,11 @@ Final section.
 
     // This pattern uses .* which should NOT match newlines
     // If dotall was enabled, this would incorrectly match functions with console on different lines
-    const results = await performSearch(
+    const results = (await performSearch(
       'function.*console',
       'project',
       { matchCase: false, wholeWord: false, useRegex: true, fileMask: 'multiline-test-file.md', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     // The test file has "function hello() {" on one line and "console.log" on the next
@@ -216,11 +216,11 @@ Final section.
     log('   🔍 Query: "function hello\\(\\) \\{\\n  console" (regex with explicit newline)');
 
     // This pattern uses explicit \n to match across lines
-    const results = await performSearch(
+    const results = (await performSearch(
       'function hello\\(\\) \\{\n  console',
       'project',
       { matchCase: false, wholeWord: false, useRegex: true, fileMask: 'multiline-test-file.md', multiline: true }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     assert.ok(results.length >= 1, 'Should find pattern with explicit newline');

--- a/src/__tests__/e2e/suite/rg-env-mismatch.test.ts
+++ b/src/__tests__/e2e/suite/rg-env-mismatch.test.ts
@@ -51,7 +51,7 @@ suite('Ripgrep Environment Mismatch', () => {
       fileMask: ''
     };
 
-    const results = await performSearch('updated', 'project', options, undefined, undefined, 200);
+    const results = (await performSearch('updated', 'project', options, undefined, undefined, 200)).results;
 
     // The fixture workspace contains this token in test.js, so search should succeed.
     assert.ok(results.length > 0, 'Expected results via fallback from bad rg override');

--- a/src/__tests__/e2e/suite/sidebar-integration.test.ts
+++ b/src/__tests__/e2e/suite/sidebar-integration.test.ts
@@ -80,12 +80,12 @@ const findMeSidebar = "unique_sidebar_search_term_12345";
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Perform search
-    const results = await performSearch(
+    const results = (await performSearch(
       'sidebarTest',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '*.ts' },
       testWorkspaceFolder.uri.fsPath
-    );
+    )).results;
 
     assert.ok(results.length > 0, 'Should find search results in project');
   });
@@ -98,12 +98,12 @@ const findMeSidebar = "unique_sidebar_search_term_12345";
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Perform regex search
-    const results = await performSearch(
+    const results = (await performSearch(
       'sidebar.*Test',
       'project',
       { matchCase: false, wholeWord: false, useRegex: true, fileMask: '*.ts' },
       testWorkspaceFolder.uri.fsPath
-    );
+    )).results;
 
     assert.ok(results.length > 0, 'Should find results with regex pattern');
   });
@@ -116,12 +116,12 @@ const findMeSidebar = "unique_sidebar_search_term_12345";
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Case-sensitive search
-    const results = await performSearch(
+    const results = (await performSearch(
       'SidebarTestClass',
       'project',
       { matchCase: true, wholeWord: false, useRegex: false, fileMask: '*.ts' },
       testWorkspaceFolder.uri.fsPath
-    );
+    )).results;
 
     assert.ok(results.length > 0, 'Should find exact case match');
   });
@@ -134,12 +134,12 @@ const findMeSidebar = "unique_sidebar_search_term_12345";
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Search with file mask
-    const results = await performSearch(
+    const results = (await performSearch(
       'sidebar',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '*.ts' },
       testWorkspaceFolder.uri.fsPath
-    );
+    )).results;
 
     assert.ok(results.length > 0, 'Should respect file mask in sidebar');
   });
@@ -152,12 +152,12 @@ const findMeSidebar = "unique_sidebar_search_term_12345";
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Whole word search
-    const results = await performSearch(
+    const results = (await performSearch(
       'sidebar',
       'project',
       { matchCase: false, wholeWord: true, useRegex: false, fileMask: '*.ts' },
       testWorkspaceFolder.uri.fsPath
-    );
+    )).results;
 
     assert.ok(results.length > 0, 'Should find whole word matches');
   });
@@ -743,11 +743,11 @@ const findMeSidebar = "unique_sidebar_search_term_12345";
     });
 
     // Trigger search by simulating the webview sending runSearch message
-    const results = await performSearch(
+    const results = (await performSearch(
       searchQuery,
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '' }
-    );
+    )).results;
 
     assert.ok(results.length > 0, 'Search should return results');
 

--- a/src/__tests__/e2e/suite/webview-integration.test.ts
+++ b/src/__tests__/e2e/suite/webview-integration.test.ts
@@ -89,16 +89,17 @@ const findMe = "unique_search_term_12345";
     while (Date.now() - start < timeout) {
       attempts++;
       const results = await performSearch(query, scope, options, directoryPath, modulePath);
-      if (results.length >= expectedCount) {
+      const searchResults = results.results;
+      if (searchResults.length >= expectedCount) {
         if (attempts > 1) {
           log(`   ⏳ Found after ${attempts} attempts (${Date.now() - start}ms)`);
         }
-        return results;
+        return searchResults;
       }
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
     log(`   ❌ Failed after ${attempts} attempts (${Date.now() - start}ms)`);
-    return await performSearch(query, scope, options, directoryPath, modulePath);
+    return (await performSearch(query, scope, options, directoryPath, modulePath)).results;
   }
 
   after(async () => {
@@ -177,22 +178,22 @@ const findMe = "unique_search_term_12345";
     log(`   📁 File: ${testFilePath}`);
     log('   🔍 Query: "TestClass" (matchCase: true)');
 
-    const caseSensitiveResults = await performSearch(
+    const caseSensitiveResults = (await performSearch(
       'TestClass',
       'project',
       { matchCase: true, wholeWord: false, useRegex: false, fileMask: '' }
-    );
+    )).results;
 
     log(`   📊 Found ${caseSensitiveResults.length} result(s)`);
 
     await step('Searching for "testclass" (wrong case) with case sensitivity');
     log('   🔍 Query: "testclass" (matchCase: true)');
 
-    const wrongCaseResults = await performSearch(
+    const wrongCaseResults = (await performSearch(
       'testclass',
       'project',
       { matchCase: true, wholeWord: false, useRegex: false, fileMask: '' }
-    );
+    )).results;
 
     log(`   📊 Found ${wrongCaseResults.length} result(s)`);
 
@@ -232,11 +233,11 @@ const findMe = "unique_search_term_12345";
     log(`   📁 File: ${testFilePath}`);
     log('   🔍 Query: "this_text_definitely_does_not_exist_xyz789"');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'this_text_definitely_does_not_exist_xyz789',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '' }
-    );
+    )).results;
 
     log(`   📊 Found ${results.length} result(s)`);
     assert.strictEqual(results.length, 0, 'Should return empty array for non-existent text');
@@ -552,11 +553,11 @@ const c = "word_to_replace";`;
     await step('Searching with empty query');
     log('   🔍 Query: "" (empty string)');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       '',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '' }
-    );
+    )).results;
 
     log(`   📊 Results: ${results.length}`);
     assert.strictEqual(results.length, 0, 'Empty query should return no results');
@@ -569,11 +570,11 @@ const c = "word_to_replace";`;
     await step('Searching with single character query');
     log('   🔍 Query: "a" (single character)');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       'a',
       'project',
       { matchCase: false, wholeWord: false, useRegex: false, fileMask: '' }
-    );
+    )).results;
 
     log(`   📊 Results: ${results.length}`);
     assert.strictEqual(results.length, 0, 'Single character query should return no results');
@@ -586,11 +587,11 @@ const c = "word_to_replace";`;
     await step('Searching with invalid regex pattern');
     log('   🔍 Query: "[invalid(regex" (invalid regex)');
 
-    const results = await performSearch(
+    const results = (await performSearch(
       '[invalid(regex',
       'project',
       { matchCase: false, wholeWord: false, useRegex: true, fileMask: '' }
-    );
+    )).results;
 
     log(`   📊 Results: ${results.length}`);
     assert.strictEqual(results.length, 0, 'Invalid regex should return no results without crashing');

--- a/src/__tests__/quickPick.test.ts
+++ b/src/__tests__/quickPick.test.ts
@@ -38,7 +38,7 @@ describe('quickPickCommand', () => {
   });
 
   it('creates and shows a QuickPick with toggle buttons', async () => {
-    performSearchMock.mockResolvedValue([]);
+    performSearchMock.mockResolvedValue({ results: [], timedOut: false, cancelled: false, resultCapHit: false });
     await quickPickCommand(createContext());
 
     const created = (vscode.window.createQuickPick as jest.Mock).mock.results[0].value;
@@ -81,7 +81,7 @@ describe('quickPickCommand', () => {
       preview: 'const foo = 1;',
       previewMatchRange: { start: 6, end: 9 }
     };
-    performSearchMock.mockResolvedValue([result]);
+    performSearchMock.mockResolvedValue({ results: [result], timedOut: false, cancelled: false, resultCapHit: false });
 
     await quickPickCommand(createContext());
 
@@ -125,7 +125,7 @@ describe('quickPickCommand', () => {
       dispose: jest.fn()
     });
 
-    performSearchMock.mockResolvedValue([]);
+    performSearchMock.mockResolvedValue({ results: [], timedOut: false, cancelled: false, resultCapHit: false });
     await quickPickCommand(createContext());
 
     const created = (vscode.window.createQuickPick as jest.Mock).mock.results[0].value;
@@ -175,7 +175,12 @@ describe('quickPickCommand', () => {
       preview: 'const foo = 1;',
       previewMatchRange: { start: 6, end: 9 }
     };
-    performSearchMock.mockResolvedValue(Array.from({ length: 50 }, () => result));
+    performSearchMock.mockResolvedValue({
+      results: Array.from({ length: 50 }, () => result),
+      timedOut: false,
+      cancelled: false,
+      resultCapHit: true,
+    });
 
     const ctx = createContext();
     await quickPickCommand(ctx);
@@ -236,7 +241,12 @@ describe('quickPickCommand', () => {
       preview: 'const foo = 1;',
       previewMatchRange: { start: 6, end: 9 }
     };
-    performSearchMock.mockResolvedValue(Array.from({ length: 2 }, () => result));
+    performSearchMock.mockResolvedValue({
+      results: Array.from({ length: 2 }, () => result),
+      timedOut: false,
+      cancelled: false,
+      resultCapHit: false,
+    });
 
     await quickPickCommand(createContext());
 
@@ -296,7 +306,7 @@ describe('quickPickReplaceCommand', () => {
       preview: 'const foo = 1;',
       previewMatchRange: { start: 6, end: 9 }
     };
-    performSearchMock.mockResolvedValue([result]);
+    performSearchMock.mockResolvedValue({ results: [result], timedOut: false, cancelled: false, resultCapHit: false });
     (vscode.window.showInputBox as jest.Mock).mockResolvedValue('bar');
     (vscode.window.showQuickPick as jest.Mock).mockResolvedValue({ label: 'Replace One' });
 
@@ -351,7 +361,12 @@ describe('quickPickReplaceCommand', () => {
       preview: 'const foo = 1;',
       previewMatchRange: { start: 6, end: 9 }
     };
-    performSearchMock.mockResolvedValue(Array.from({ length: 50 }, () => result));
+    performSearchMock.mockResolvedValue({
+      results: Array.from({ length: 50 }, () => result),
+      timedOut: false,
+      cancelled: false,
+      resultCapHit: true,
+    });
 
     const ctx = createContext();
     await quickPickReplaceCommand(ctx);

--- a/src/__tests__/replacer.test.ts
+++ b/src/__tests__/replacer.test.ts
@@ -92,7 +92,12 @@ describe('Replacer', () => {
         }
       ];
 
-      (search.performSearch as jest.Mock).mockResolvedValue(mockResults);
+      (search.performSearch as jest.Mock).mockResolvedValue({
+        results: mockResults,
+        timedOut: false,
+        cancelled: false,
+        resultCapHit: false,
+      });
 
       await replaceAll(query, replaceText, scope, defaultOptions, undefined, undefined, onRefresh);
 
@@ -110,7 +115,12 @@ describe('Replacer', () => {
     });
 
     test('should show message if no results found', async () => {
-      (search.performSearch as jest.Mock).mockResolvedValue([]);
+      (search.performSearch as jest.Mock).mockResolvedValue({
+        results: [],
+        timedOut: false,
+        cancelled: false,
+        resultCapHit: false,
+      });
       const onRefresh = jest.fn();
 
       await replaceAll('query', 'replace', 'project', defaultOptions, undefined, undefined, onRefresh);
@@ -121,16 +131,21 @@ describe('Replacer', () => {
     });
 
     test('should handle applyEdit failure', async () => {
-      (search.performSearch as jest.Mock).mockResolvedValue([{
-        uri: 'file:///test.ts',
-        line: 0,
-        character: 0,
-        length: 1,
-        fileName: 'test.ts',
-        relativePath: 'test.ts',
-        preview: 'a',
-        previewMatchRange: { start: 0, end: 1 }
-      }]);
+      (search.performSearch as jest.Mock).mockResolvedValue({
+        results: [{
+          uri: 'file:///test.ts',
+          line: 0,
+          character: 0,
+          length: 1,
+          fileName: 'test.ts',
+          relativePath: 'test.ts',
+          preview: 'a',
+          previewMatchRange: { start: 0, end: 1 }
+        }],
+        timedOut: false,
+        cancelled: false,
+        resultCapHit: false,
+      });
       
       (vscode.workspace.applyEdit as unknown as jest.Mock).mockResolvedValue(false);
       const onRefresh = jest.fn();
@@ -155,7 +170,12 @@ describe('Replacer', () => {
         }
       ];
 
-      (search.performSearch as jest.Mock).mockResolvedValue(mockResults);
+      (search.performSearch as jest.Mock).mockResolvedValue({
+        results: mockResults,
+        timedOut: false,
+        cancelled: false,
+        resultCapHit: false,
+      });
       
       // Mock save to throw error
       const mockDocWithError = {
@@ -201,7 +221,12 @@ describe('Replacer', () => {
     });
 
     test('should pass directory and module paths to performSearch', async () => {
-      (search.performSearch as jest.Mock).mockResolvedValue([]);
+      (search.performSearch as jest.Mock).mockResolvedValue({
+        results: [],
+        timedOut: false,
+        cancelled: false,
+        resultCapHit: false,
+      });
       const onRefresh = jest.fn();
 
       await replaceAll('query', 'replace', 'directory', defaultOptions, '/test/dir', undefined, onRefresh);

--- a/src/__tests__/search.rootsFilter.test.ts
+++ b/src/__tests__/search.rootsFilter.test.ts
@@ -63,7 +63,7 @@ describe('Search roots filtering', () => {
 
     const results = await performSearch('test', 'directory', defaultOptions, rootDir);
 
-    expect(results).toHaveLength(1);
-    expect(results[0].uri).toBe('/workspace/src/in.ts');
+    expect(results.results).toHaveLength(1);
+    expect(results.results[0].uri).toBe('/workspace/src/in.ts');
   });
 });

--- a/src/__tests__/search.test.ts
+++ b/src/__tests__/search.test.ts
@@ -25,22 +25,27 @@ describe('Search', () => {
     describe('input validation', () => {
       test('should return empty array for empty query', async () => {
         const results = await performSearch('', 'project', defaultOptions);
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should return empty array for whitespace-only query', async () => {
         const results = await performSearch('   ', 'project', defaultOptions);
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should return empty array for query shorter than 2 characters', async () => {
         const results = await performSearch('a', 'project', defaultOptions);
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should return empty array for invalid regex', async () => {
         const results = await performSearch('[invalid', 'project', { ...defaultOptions, useRegex: true });
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
+      });
+
+      test('should return empty array for directory scope queries shorter than 3 characters', async () => {
+        const results = await performSearch('ab', 'directory', defaultOptions, '/test/dir');
+        expect(results.results).toEqual([]);
       });
     });
 
@@ -62,8 +67,8 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'directory', defaultOptions, testDir);
 
-        expect(results.length).toBe(1);
-        expect(results[0].preview).toContain('test');
+        expect(results.results.length).toBe(1);
+        expect(results.results[0].preview).toContain('test');
       });
 
       test('should return empty for non-existent directory', async () => {
@@ -71,12 +76,12 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'directory', defaultOptions, '/nonexistent');
 
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should return empty for empty directory path', async () => {
         const results = await performSearch('test', 'directory', defaultOptions, '');
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should search file if directory path points to a file', async () => {
@@ -93,7 +98,7 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'directory', defaultOptions, testFilePath);
 
-        expect(results.length).toBe(1);
+        expect(results.results.length).toBe(1);
       });
     });
 
@@ -115,7 +120,7 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'module', defaultOptions, undefined, modulePath);
 
-        expect(results.length).toBe(1);
+        expect(results.results.length).toBe(1);
       });
 
       test('should return empty for non-existent module path', async () => {
@@ -123,12 +128,12 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'module', defaultOptions, undefined, '/nonexistent/module');
 
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should return empty for module scope without modulePath', async () => {
         const results = await performSearch('test', 'module', defaultOptions);
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
     });
 
@@ -147,7 +152,7 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'project', defaultOptions);
 
-        expect(results.length).toBe(1);
+        expect(results.results.length).toBe(1);
       });
 
       test('should return empty when no workspace folders', async () => {
@@ -155,7 +160,7 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'project', defaultOptions);
 
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
     });
 
@@ -264,7 +269,7 @@ describe('Search', () => {
         const results = await performSearch('test', 'project', defaultOptions);
 
         expect(mockWorkspaceFs.readFile).not.toHaveBeenCalled();
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
       });
 
       test('should respect file mask filter', async () => {
@@ -331,8 +336,8 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'project', defaultOptions);
 
-        expect(results.length).toBe(1);
-        expect(results[0].preview).toContain('test');
+        expect(results.results.length).toBe(1);
+        expect(results.results[0].preview).toContain('test');
       });
     });
 
@@ -354,8 +359,8 @@ describe('Search', () => {
         const results = await performSearch('test', 'project', defaultOptions);
 
         // Should have many results but not exceed reasonable limits
-        expect(results.length).toBeGreaterThan(0);
-        expect(results.length).toBeLessThanOrEqual(5000);
+        expect(results.results.length).toBeGreaterThan(0);
+        expect(results.results.length).toBeLessThanOrEqual(5000);
       });
     });
 
@@ -374,8 +379,8 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'project', defaultOptions);
 
-        expect(results.length).toBe(1);
-        expect(results[0]).toMatchObject({
+        expect(results.results.length).toBe(1);
+        expect(results.results[0]).toMatchObject({
           fileName: 'file.ts',
           relativePath: 'file.ts',
           line: 0,
@@ -383,8 +388,8 @@ describe('Search', () => {
           length: 4,
           preview: 'const test = "hello";' // trimmed preview
         });
-        expect(results[0].uri).toContain('file.ts');
-        expect(results[0].previewMatchRange).toBeDefined();
+        expect(results.results[0].uri).toContain('file.ts');
+        expect(results.results[0].previewMatchRange).toBeDefined();
       });
 
       test('should handle multiple matches on same line', async () => {
@@ -401,8 +406,8 @@ describe('Search', () => {
 
         const results = await performSearch('test', 'project', defaultOptions);
 
-        expect(results.length).toBe(1);
-        expect(results[0].previewMatchRanges).toHaveLength(3);
+        expect(results.results.length).toBe(1);
+        expect(results.results[0].previewMatchRanges).toHaveLength(3);
       });
     });
 
@@ -417,7 +422,7 @@ describe('Search', () => {
         const results = await performSearch('test', 'project', defaultOptions);
 
         // Should not throw, just return empty results
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
         // The readDirectory should have been called
         expect(mockWorkspaceFs.readDirectory).toHaveBeenCalled();
       });
@@ -435,7 +440,7 @@ describe('Search', () => {
         const results = await performSearch('test', 'project', defaultOptions);
 
         // Should not throw, just return empty results
-        expect(results).toEqual([]);
+        expect(results.results).toEqual([]);
         expect(mockWorkspaceFs.readFile).toHaveBeenCalled();
       });
     });
@@ -458,7 +463,7 @@ describe('Search', () => {
 
       const results = await performSearch('test', 'project', defaultOptions, undefined, undefined, 10);
 
-      expect(results.length).toBe(10);
+      expect(results.results.length).toBe(10);
     });
 
     test('should return all results when under maxResults limit', async () => {
@@ -475,7 +480,7 @@ describe('Search', () => {
 
       const results = await performSearch('test', 'project', defaultOptions, undefined, undefined, 1000);
 
-      expect(results.length).toBe(2);
+      expect(results.results.length).toBe(2);
     });
 
     test('should use default maxResults of 10000 when not specified', async () => {
@@ -493,7 +498,7 @@ describe('Search', () => {
       // Just verify it doesn't throw and returns results
       const results = await performSearch('test', 'project', defaultOptions);
 
-      expect(results.length).toBe(1);
+      expect(results.results.length).toBe(1);
     });
 
     test('should handle maxResults of 0 or negative by using default', async () => {
@@ -512,7 +517,7 @@ describe('Search', () => {
       // With maxResults = 0, should still return results (uses default)
       const results = await performSearch('test', 'project', defaultOptions, undefined, undefined, 0);
 
-      expect(results.length).toBe(10);
+      expect(results.results.length).toBe(10);
     });
   });
 });

--- a/src/__tests__/telemetry/searchTelemetry.test.ts
+++ b/src/__tests__/telemetry/searchTelemetry.test.ts
@@ -12,9 +12,23 @@ import * as vscode from 'vscode';
 
 // Mock performSearch to avoid real file system access
 jest.mock('../../search', () => ({
-  performSearch: jest.fn().mockResolvedValue([
-    { uri: 'file:///test.ts', line: 1, character: 0, length: 3, preview: 'foo', fileName: 'test.ts' },
-  ]),
+  performSearch: jest.fn().mockResolvedValue({
+    results: [
+      {
+        uri: 'file:///test.ts',
+        line: 1,
+        character: 0,
+        length: 3,
+        preview: 'foo',
+        fileName: 'test.ts',
+        relativePath: 'test.ts',
+        previewMatchRange: { start: 0, end: 3 },
+      },
+    ],
+    timedOut: false,
+    cancelled: false,
+    resultCapHit: false,
+  }),
 }));
 
 // Mock telemetry module so we can spy on getTelemetryLogger
@@ -122,6 +136,9 @@ describe('search_completed telemetry integration', () => {
         match_case: false,
         whole_word: false,
         multiline: false,
+        timed_out: false,
+        cancelled: false,
+        result_cap_hit: false,
       }));
 
       // duration_ms should be a non-negative number
@@ -129,6 +146,39 @@ describe('search_completed telemetry integration', () => {
         (c: unknown[]) => c[0] === 'search_completed'
       )!;
       expect(call[1].duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should include timeout/cancel/result cap flags when search completes', async () => {
+      performSearchMock.mockResolvedValueOnce({
+        results: [
+          {
+            uri: 'file:///test.ts',
+            line: 1,
+            character: 0,
+            length: 3,
+            preview: 'foo',
+            fileName: 'test.ts',
+            relativePath: 'test.ts',
+            previewMatchRange: { start: 0, end: 3 },
+          },
+        ],
+        timedOut: true,
+        cancelled: true,
+        resultCapHit: true,
+      });
+
+      await handler.handle({
+        type: 'runSearch',
+        query: 'test',
+        scope: 'project',
+        options: { matchCase: false, wholeWord: false, useRegex: false, multiline: false, fileMask: '' },
+      });
+
+      expect(mockLogUsage).toHaveBeenCalledWith('search_completed', expect.objectContaining({
+        timed_out: true,
+        cancelled: true,
+        result_cap_hit: true,
+      }));
     });
 
     it('should include query_length in telemetry', async () => {
@@ -170,6 +220,9 @@ describe('search_completed telemetry integration', () => {
         include_comments: false,
         include_strings: false,
         file_mask_count: 2,
+        timed_out: false,
+        cancelled: false,
+        result_cap_hit: false,
       }));
     });
 
@@ -197,6 +250,9 @@ describe('search_completed telemetry integration', () => {
       expect(mockLogUsage).toHaveBeenCalledWith('search_completed', expect.objectContaining({
         error: 'search failed',
         results_count: 0,
+        timed_out: false,
+        cancelled: false,
+        result_cap_hit: false,
       }));
     });
 

--- a/src/commands/quickPick.ts
+++ b/src/commands/quickPick.ts
@@ -74,10 +74,11 @@ export async function quickPickCommand(ctx: CommandContext): Promise<void> {
 
     try {
       const results = await performSearch(trimmed, 'project', options, undefined, undefined, MAX_ITEMS, true);
+      const searchResults = results.results;
       if (disposed || currentSearchId !== searchCounter) return;
 
-      const items = results.slice(0, MAX_ITEMS).map((result) => toQuickPickItem(result));
-      if (results.length >= MAX_ITEMS) {
+      const items = searchResults.slice(0, MAX_ITEMS).map((result) => toQuickPickItem(result));
+      if (searchResults.length >= MAX_ITEMS) {
         items.push({
           label: '$(link-external) Show all results in Rifler',
           description: '',

--- a/src/commands/quickPickReplace.ts
+++ b/src/commands/quickPickReplace.ts
@@ -75,10 +75,11 @@ export async function quickPickReplaceCommand(ctx: CommandContext): Promise<void
 
     try {
       const results = await performSearch(trimmed, 'project', options, undefined, undefined, MAX_ITEMS, true);
+      const searchResults = results.results;
       if (disposed || currentSearchId !== searchCounter) return;
 
-      const items = results.slice(0, MAX_ITEMS).map((result) => toQuickPickItem(result));
-      if (results.length >= MAX_ITEMS) {
+      const items = searchResults.slice(0, MAX_ITEMS).map((result) => toQuickPickItem(result));
+      if (searchResults.length >= MAX_ITEMS) {
         items.push({
           label: '$(link-external) Show all results in Rifler',
           description: '',

--- a/src/messaging/registerCommonHandlers.ts
+++ b/src/messaging/registerCommonHandlers.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { MessageHandler } from './handler';
-import { performSearch } from '../search';
+import { performSearch, SearchOutcome } from '../search';
 import { replaceOne, replaceAll } from '../replacer';
 import { validateRegex, validateFileMask, SearchOptions, SearchScope, SearchResult } from '../utils';
 import { getTelemetryLogger } from '../telemetry';
@@ -40,6 +40,15 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
       ? (msg.options.fileMask ? `${msg.options.fileMask},${msg.exclusionPatterns}` : msg.exclusionPatterns)
       : (msg.options.fileMask || '');
 
+    if (msg.scope === 'directory' && msg.query?.trim().length > 0 && msg.query.trim().length < 3) {
+      deps.postMessage({
+        type: 'error',
+        message: 'Directory scope requires at least 3 characters.'
+      });
+      deps.postMessage({ type: 'searchResults', results: [], maxResults: 10000 });
+      return;
+    }
+
     let directoryPath = msg.directoryPath;
     if (msg.scope === 'directory' && msg.directoryPath && vscode.workspace.workspaceFolders?.length) {
       try {
@@ -57,8 +66,9 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
 
     let results: SearchResult[] = [];
     let searchError: string | undefined;
+    let searchOutcome: SearchOutcome | undefined;
     try {
-      results = await performSearch(
+      searchOutcome = await performSearch(
         msg.query,
         msg.scope,
         { ...msg.options, fileMask: mergedFileMask },
@@ -67,12 +77,16 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
         10000,
         msg.smartExcludesEnabled ?? true
       );
+      results = searchOutcome.results;
       console.log('[Rifler] Search returned', results.length, 'results');
     } catch (error) {
       searchError = error instanceof Error ? error.message : String(error);
       throw error;
     } finally {
       const durationMs = Date.now() - startTime;
+      const timedOut = searchOutcome?.timedOut ?? false;
+      const cancelled = searchOutcome?.cancelled ?? false;
+      const resultCapHit = searchOutcome?.resultCapHit ?? false;
 
       telemetryLogger?.logUsage('search_completed', {
         duration_ms: durationMs,
@@ -92,6 +106,9 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
         file_mask_count: (mergedFileMask ? mergedFileMask.split(/[;,]+/).filter(Boolean).length : 0),
         has_exclusion_patterns: !!msg.exclusionPatterns,
         query_rows: (message as { queryRows?: number }).queryRows ?? 1,
+        timed_out: timedOut,
+        cancelled,
+        result_cap_hit: resultCapHit,
         error: searchError,
       });
 
@@ -114,6 +131,9 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
         file_mask_count: (mergedFileMask ? mergedFileMask.split(/[;,]+/).filter(Boolean).length : 0),
         has_exclusion_patterns: !!msg.exclusionPatterns,
         query_rows: (message as { queryRows?: number }).queryRows ?? 1,
+        timed_out: timedOut,
+        cancelled,
+        result_cap_hit: resultCapHit,
         error: searchError,
       };
     }
@@ -252,7 +272,7 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
           msg.directoryPath,
           msg.modulePath
         );
-        deps.postMessage({ type: 'searchResults', results, maxResults: 10000 });
+        deps.postMessage({ type: 'searchResults', results: results.results, maxResults: 10000 });
       }
     );
     const telemetryLogger = getTelemetryLogger();

--- a/src/replacer.ts
+++ b/src/replacer.ts
@@ -52,7 +52,8 @@ export async function replaceAll(
     }
 
     const results = await performSearch(query, scope, options, directoryPath, modulePath);
-    if (results.length === 0) {
+    const searchResults = results.results;
+    if (searchResults.length === 0) {
       vscode.window.showInformationMessage('No occurrences found to replace.');
       return;
     }
@@ -61,7 +62,7 @@ export async function replaceAll(
     // Only enforce validation if workspace folders exist (skip in tests/edge cases)
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (workspaceFolders && workspaceFolders.length > 0) {
-      for (const result of results) {
+      for (const result of searchResults) {
         if (!validateUriString(result.uri)) {
           throw new Error('Security: All URIs must be within workspace');
         }
@@ -71,7 +72,7 @@ export async function replaceAll(
     const edit = new vscode.WorkspaceEdit();
     const affectedUris = new Set<string>();
     
-    for (const result of results) {
+    for (const result of searchResults) {
       const uri = vscode.Uri.parse(result.uri);
       const range = new vscode.Range(result.line, result.character, result.line, result.character + result.length);
       edit.replace(uri, range, replaceText);
@@ -91,7 +92,7 @@ export async function replaceAll(
         }
       }
 
-      vscode.window.showInformationMessage(`Replaced ${results.length} occurrences.`);
+      vscode.window.showInformationMessage(`Replaced ${searchResults.length} occurrences.`);
       // Re-run search to update UI
       await onRefresh();
     } else {

--- a/src/search.ts
+++ b/src/search.ts
@@ -73,6 +73,16 @@ function filterResultsToRoots(results: SearchResult[], roots: RootSpec[]): Searc
   });
 }
 
+export interface SearchOutcome {
+  results: SearchResult[];
+  timedOut: boolean;
+  cancelled: boolean;
+  resultCapHit: boolean;
+}
+
+const SEARCH_TIMEOUT_MS = 5000;
+const DIRECTORY_SCOPE_MIN_QUERY_LENGTH = 3;
+
 export async function performSearch(
   query: string,
   scope: SearchScope,
@@ -81,9 +91,13 @@ export async function performSearch(
   modulePath?: string,
   maxResults: number = 10000,
   smartExcludesEnabled: boolean = true
-): Promise<SearchResult[]> {
+): Promise<SearchOutcome> {
   if (!query.trim() || query.length < 2) {
-    return [];
+    return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
+  }
+
+  if (scope === 'directory' && query.trim().length < DIRECTORY_SCOPE_MIN_QUERY_LENGTH) {
+    return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
 
   options.multiline = !!options.multiline;
@@ -91,16 +105,16 @@ export async function performSearch(
   const regexValidation = validateRegex(query, options.useRegex, !!options.multiline);
   if (!regexValidation.isValid) {
     console.error('Invalid regex:', regexValidation.error);
-    return [];
+    return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
 
   if (options.useRegex && !isSafeRegex(query)) {
     console.warn('Rejected potentially unsafe regex pattern');
-    return [];
+    return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
 
   if (!buildSearchRegex(query, options)) {
-    return [];
+    return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
 
   const maskValidation = validateFileMask(options.fileMask);
@@ -112,9 +126,13 @@ export async function performSearch(
   const effectiveMaxResults = Math.max(1, Math.floor(maxResults || 10000));
   const rootSpecs = await resolveSearchRoots(scope, directoryPath, modulePath);
   if (rootSpecs.length === 0) {
-    return [];
+    return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
   const roots = rootSpecs.map((r) => r.fsPath);
+
+  let timedOut = false;
+  let cancelled = false;
+  let resultCapHit = false;
 
   cancelActiveSearch();
   const { promise, cancel } = startRipgrepSearch({
@@ -127,18 +145,30 @@ export async function performSearch(
     smartExcludesEnabled
   });
 
-  activeSearchCancel = cancel;
+  const cancelForNewSearch = (): void => {
+    cancelled = true;
+    cancel();
+  };
+
+  activeSearchCancel = cancelForNewSearch;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    cancel();
+  }, SEARCH_TIMEOUT_MS);
 
   try {
     const rawResults = await promise;
+    clearTimeout(timeoutId);
     const results = filterResultsToRoots(rawResults, rootSpecs);
     const filteredResults = await filterResultsByCodeContext(results, options);
-    if (activeSearchCancel === cancel) {
+    resultCapHit = rawResults.length >= effectiveMaxResults;
+    if (activeSearchCancel === cancelForNewSearch) {
       activeSearchCancel = undefined;
     }
-    return filteredResults;
+    return { results: filteredResults, timedOut, cancelled, resultCapHit };
   } catch (error) {
-    if (activeSearchCancel === cancel) {
+    clearTimeout(timeoutId);
+    if (activeSearchCancel === cancelForNewSearch) {
       activeSearchCancel = undefined;
     }
     console.error('Error during ripgrep search:', error);
@@ -149,7 +179,7 @@ export async function performSearch(
     try {
       const results: SearchResult[] = [];
       const regex = buildSearchRegex(query, options);
-      if (!regex) return [];
+      if (!regex) return { results: [], timedOut, cancelled, resultCapHit: false };
       const limiter = new Limiter(100);
       const perFileTimeBudgetMs = 2500;
 
@@ -163,12 +193,18 @@ export async function performSearch(
         if (results.length >= effectiveMaxResults) break;
       }
       const rootFiltered = filterResultsToRoots(results, rootSpecs);
-      return await filterResultsByCodeContext(rootFiltered, options);
+      resultCapHit = results.length >= effectiveMaxResults;
+      return {
+        results: await filterResultsByCodeContext(rootFiltered, options),
+        timedOut,
+        cancelled,
+        resultCapHit,
+      };
     } catch (fallbackError) {
       getTelemetryLogger()?.logError(fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError)), {
         stage: 'fallback',
       });
-      return [];
+      return { results: [], timedOut, cancelled, resultCapHit: false };
     }
   }
 }

--- a/src/sidebar/SidebarProvider.ts
+++ b/src/sidebar/SidebarProvider.ts
@@ -8,7 +8,7 @@ import {
   getOpenKeybindingHint
 } from '../utils';
 import { IncomingMessage } from '../messaging/types';
-import { performSearch } from '../search';
+import { performSearch, SearchOutcome } from '../search';
 import { replaceAll } from '../replacer';
 import { getWebviewHtml } from '../webview/webviewUtils';
 import { MessageHandler } from '../messaging/handler';
@@ -355,12 +355,22 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    if (message.scope === 'directory' && message.query.trim().length > 0 && message.query.trim().length < 3) {
+      this._view?.webview.postMessage({
+        type: 'error',
+        message: 'Directory scope requires at least 3 characters.'
+      });
+      this._view?.webview.postMessage({ type: 'searchResults', results: [], activeIndex: -1 });
+      return;
+    }
+
     const startTime = Date.now();
     let results: SearchResult[] = [];
     let searchError: string | undefined;
+    let searchOutcome: SearchOutcome | undefined;
 
     try {
-      results = await performSearch(
+      searchOutcome = await performSearch(
         message.query,
         message.scope as SearchScope,
         message.options,
@@ -369,12 +379,16 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
         10000,
         message.smartExcludesEnabled ?? true
       );
+      results = searchOutcome.results;
     } catch (error) {
       searchError = error instanceof Error ? error.message : String(error);
       throw error;
     } finally {
       const durationMs = Date.now() - startTime;
       const telemetryLogger = getTelemetryLogger();
+      const timedOut = searchOutcome?.timedOut ?? false;
+      const cancelled = searchOutcome?.cancelled ?? false;
+      const resultCapHit = searchOutcome?.resultCapHit ?? false;
       telemetryLogger?.logUsage('search_completed', {
         duration_ms: durationMs,
         results_count: results.length,
@@ -392,6 +406,9 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
         include_strings: message.options.includeStrings ?? true,
         file_mask_count: (message.options.fileMask ? message.options.fileMask.split(/[;,]+/).filter(Boolean).length : 0),
         query_rows: message.queryRows ?? 1,
+        timed_out: timedOut,
+        cancelled,
+        result_cap_hit: resultCapHit,
         error: searchError,
       });
     }

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -464,7 +464,6 @@ console.log('[Rifler] Webview script starting...');
 
   function isReplaceActionDisabled() {
     const queryValue = queryInput ? queryInput.value.trim() : '';
-    const replaceValue = replaceInput ? replaceInput.value.trim() : '';
     return queryValue.length < 2;
   }
 
@@ -3550,6 +3549,12 @@ console.log('[Rifler] Webview script starting...');
       
       console.log('runSearch called, query:', query, 'length:', query.length, 'useRegex:', state.options.useRegex);
       
+      if (state.currentScope === 'directory' && query.trim().length > 0 && query.trim().length < 3) {
+        showPlaceholder('Directory scope needs at least 3 characters...');
+        clearResultsCountDisplay();
+        return;
+      }
+
       if (query.length < 2) {
         showPlaceholder('Type at least 2 characters...');
         clearResultsCountDisplay();

--- a/test-fixtures/workspace/.vscode/settings.json
+++ b/test-fixtures/workspace/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.minimap.enabled": false,
   "rifler.viewMode": "tab",
   "rifler.results.showCollapsed": true,
-  "rifler.openKeybindingHint": "cmd+alt+f"
+  "rifler.openKeybindingHint": "cmd+alt+f",
+  "rifler.panelLocation": "window",
+  "rifler.persistSearchState": true,
+  "rifler.persistenceScope": "off"
 }


### PR DESCRIPTION
## Summary
- add 5s search timeout with cancellation/result cap flags in search execution
- enforce 3-character minimum for directory-scope searches and surface UI error
- update telemetry payloads and tests to include timeout/cancel/result cap metadata

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` (timed out after 5m; last error was missing sidebar replace fixture files)