### PR TITLE
Improve 10k search performance and stabilize sidebar behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
           "type": "number",
           "default": 10000,
           "minimum": 100,
-          "markdownDescription": "Maximum number of search results to collect. With virtualized rendering, higher values are handled efficiently.",
+          "markdownDescription": "Maximum number of search results to collect. Set higher for broader result sets; very high values can still increase UI work depending on query breadth.",
           "order": 5
         },
         "rifler.results.showCollapsed": {
@@ -288,6 +288,12 @@
           "default": true,
           "markdownDescription": "Include string literal matches by default when running a search.",
           "order": 14
+        },
+        "rifler.debug.profileSearch": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable local search pipeline profiling logs in the webview/extension output. Intended for local debugging.",
+          "order": 99
         }
         
       }

--- a/src/codeContextFilter.ts
+++ b/src/codeContextFilter.ts
@@ -96,48 +96,56 @@ export async function filterResultsByCodeContext(
 
   const contextFiltersActive = !(includeCode && includeComments && includeStrings);
 
-  const resultsByFile = new Map<string, SearchResult[]>();
-  for (const result of results) {
+  const resultsByFile = new Map<string, Array<{ result: SearchResult; index: number }>>();
+  for (let index = 0; index < results.length; index++) {
+    const result = results[index];
     const list = resultsByFile.get(result.uri) || [];
-    list.push(result);
+    list.push({ result, index });
     resultsByFile.set(result.uri, list);
   }
 
-  const filtered: SearchResult[] = [];
+  const entries = Array.from(resultsByFile.entries());
+  const filteredByEntry: Array<Array<{ result: SearchResult; index: number }>> = new Array(entries.length);
+  const concurrency = Math.min(8, entries.length);
+  let nextIndex = 0;
 
-  for (const [uri, fileResults] of resultsByFile.entries()) {
+  const processEntry = async (entry: [string, Array<{ result: SearchResult; index: number }>]): Promise<Array<{ result: SearchResult; index: number }>> => {
+    const [uri, indexedResults] = entry;
+    const fileResults = indexedResults.map((item) => item.result);
     const languageId = getLanguageIdFromFileName(fileResults[0]?.fileName || '');
+
+    const passthrough = (): Array<{ result: SearchResult; index: number }> => indexedResults;
+
     if (!languageId || !SUPPORTED_LANGUAGES.has(languageId)) {
       if (contextFiltersActive && !includeStrings) {
-        continue;
+        return [];
       }
-      filtered.push(...fileResults);
-      continue;
+      return passthrough();
     }
 
     const config = LANGUAGE_CONFIGS[languageId];
     if (!config) {
       if (contextFiltersActive && !includeStrings) {
-        continue;
+        return [];
       }
-      filtered.push(...fileResults);
-      continue;
+      return passthrough();
     }
 
     const content = await readFileContent(uri);
     if (!content) {
-      filtered.push(...fileResults);
-      continue;
+      return passthrough();
     }
 
     const lines = content.split(/\r?\n/);
     const lineContexts = parseLineContexts(lines, config);
+    const filteredLocal: Array<{ result: SearchResult; index: number }> = [];
 
-    for (const result of fileResults) {
+    for (const indexed of indexedResults) {
+      const result = indexed.result;
       const lineIndex = result.line;
       const lineContext = lineContexts[lineIndex];
       if (!lineContext) {
-        filtered.push(result);
+        filteredLocal.push(indexed);
         continue;
       }
 
@@ -181,18 +189,41 @@ export async function filterResultsByCodeContext(
         end: Math.max(0, firstRange.end - leadingWhitespace)
       };
 
-      filtered.push({
-        ...result,
-        character: firstRange.start,
-        length: Math.max(0, firstRange.end - firstRange.start),
-        matchRanges: allowedMatchRanges,
-        previewMatchRanges,
-        previewMatchRange: firstPreviewRange
+      filteredLocal.push({
+        index: indexed.index,
+        result: {
+          ...result,
+          character: firstRange.start,
+          length: Math.max(0, firstRange.end - firstRange.start),
+          matchRanges: allowedMatchRanges,
+          previewMatchRanges,
+          previewMatchRange: firstPreviewRange,
+        }
       });
     }
-  }
 
-  return filtered;
+    return filteredLocal;
+  };
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const current = nextIndex;
+      nextIndex += 1;
+      if (current >= entries.length) {
+        return;
+      }
+      filteredByEntry[current] = await processEntry(entries[current]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+  const flattened = filteredByEntry
+    .flat()
+    .sort((a, b) => a.index - b.index)
+    .map((item) => item.result);
+
+  return flattened;
 }
 
 function getLanguageIdFromFileName(fileName: string): string | undefined {
@@ -203,6 +234,10 @@ function getLanguageIdFromFileName(fileName: string): string | undefined {
 async function readFileContent(uriString: string): Promise<string> {
   try {
     const uri = vscode.Uri.parse(uriString);
+    const openDoc = vscode.workspace.textDocuments.find((doc) => doc.uri.toString() === uriString);
+    if (openDoc) {
+      return openDoc.getText();
+    }
     const data = await vscode.workspace.fs.readFile(uri);
     return Buffer.from(data).toString('utf8');
   } catch {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -306,6 +306,29 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize StateStore
   stateStore = new StateStore(context);
 
+  // One-time migration cleanup for legacy heavy global state payloads.
+  try {
+    const globalSidebarState = context.globalState.get('rifler.sidebarState') as Record<string, unknown> | undefined;
+    const globalPersistedState = context.globalState.get('rifler.persistedSearchState') as Record<string, unknown> | undefined;
+    const hasLargeGlobalSidebarState = !!globalSidebarState && (
+      Object.prototype.hasOwnProperty.call(globalSidebarState, 'results')
+      || Object.prototype.hasOwnProperty.call(globalSidebarState, 'lastPreview')
+      || Object.prototype.hasOwnProperty.call(globalSidebarState, 'lspResultsCache')
+    );
+    const hasLargeGlobalPersistedState = !!globalPersistedState && (
+      Object.prototype.hasOwnProperty.call(globalPersistedState, 'results')
+      || Object.prototype.hasOwnProperty.call(globalPersistedState, 'lastPreview')
+      || Object.prototype.hasOwnProperty.call(globalPersistedState, 'lspResultsCache')
+    );
+    if (hasLargeGlobalSidebarState || hasLargeGlobalPersistedState) {
+      void context.globalState.update('rifler.sidebarState', undefined);
+      void context.globalState.update('rifler.persistedSearchState', undefined);
+      console.log('[Rifler] Cleared legacy heavy global persisted state payloads');
+    }
+  } catch (error) {
+    console.warn('[Rifler] Failed to run persisted-state cleanup migration:', error);
+  }
+
   // Detect workspace change to clear state if needed for "fresh search" on project change
   try {
     const lastWorkspaceFolders = context.globalState.get<string[]>('rifler.lastWorkspaceFolders');
@@ -562,12 +585,14 @@ export async function activate(context: vscode.ExtensionContext) {
       if (e.affectsConfiguration('rifler')) {
         const config = vscode.workspace.getConfiguration('rifler');
         const resultsShowCollapsed = config.get<boolean>('results.showCollapsed', false);
+        const profileSearch = config.get<boolean>('debug.profileSearch', false);
         
         // Send updated config to panel webview if visible
         if (panelManager.panel?.visible) {
           panelManager.panel.webview.postMessage({
             type: 'config',
-            resultsShowCollapsed
+            resultsShowCollapsed,
+            profileSearch
           });
         }
 

--- a/src/messaging/registerCommonHandlers.ts
+++ b/src/messaging/registerCommonHandlers.ts
@@ -30,7 +30,17 @@ let lastSearchTelemetry: Record<string, unknown> | undefined;
 
 export function registerCommonHandlers(handler: MessageHandler, deps: CommonHandlerDeps) {
   handler.registerHandler('runSearch', async (message) => {
-    const msg = message as { query: string; scope: SearchScope; options: SearchOptions; directoryPath?: string; modulePath?: string; smartExcludesEnabled?: boolean; exclusionPatterns?: string };
+    const msg = message as {
+      query: string;
+      scope: SearchScope;
+      options: SearchOptions;
+      maxResults?: number;
+      directoryPath?: string;
+      modulePath?: string;
+      smartExcludesEnabled?: boolean;
+      exclusionPatterns?: string;
+      requestId?: string;
+    };
 
     const telemetryLogger = getTelemetryLogger();
 
@@ -39,13 +49,14 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
     const mergedFileMask = (msg.smartExcludesEnabled && msg.exclusionPatterns)
       ? (msg.options.fileMask ? `${msg.options.fileMask},${msg.exclusionPatterns}` : msg.exclusionPatterns)
       : (msg.options.fileMask || '');
+    const effectiveMaxResults = Math.max(1, Math.floor(msg.maxResults ?? 10000));
 
     if (msg.scope === 'directory' && msg.query?.trim().length > 0 && msg.query.trim().length < 3) {
       deps.postMessage({
         type: 'error',
         message: 'Directory scope requires at least 3 characters.'
       });
-      deps.postMessage({ type: 'searchResults', results: [], maxResults: 10000 });
+      deps.postMessage({ type: 'searchResults', results: [], maxResults: effectiveMaxResults });
       return;
     }
 
@@ -59,7 +70,7 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
           type: 'error',
           message: 'Directory path must be within the workspace.'
         });
-        deps.postMessage({ type: 'searchResults', results: [], maxResults: 10000 });
+        deps.postMessage({ type: 'searchResults', results: [], maxResults: effectiveMaxResults });
         return;
       }
     }
@@ -74,8 +85,9 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
         { ...msg.options, fileMask: mergedFileMask },
         directoryPath,
         msg.modulePath,
-        10000,
-        msg.smartExcludesEnabled ?? true
+        effectiveMaxResults,
+        msg.smartExcludesEnabled ?? true,
+        msg.requestId
       );
       results = searchOutcome.results;
       console.log('[Rifler] Search returned', results.length, 'results');
@@ -109,6 +121,12 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
         timed_out: timedOut,
         cancelled,
         result_cap_hit: resultCapHit,
+        request_id: msg.requestId,
+        phase_resolve_roots_ms: searchOutcome?.profile?.durationsMs.resolveRoots,
+        phase_rg_ms: searchOutcome?.profile?.durationsMs.rgSearch,
+        phase_root_filter_ms: searchOutcome?.profile?.durationsMs.rootFilter,
+        phase_context_filter_ms: searchOutcome?.profile?.durationsMs.contextFilter,
+        payload_bytes_estimate: searchOutcome?.profile?.serializedBytes,
         error: searchError,
       });
 
@@ -134,6 +152,12 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
         timed_out: timedOut,
         cancelled,
         result_cap_hit: resultCapHit,
+        request_id: msg.requestId,
+        phase_resolve_roots_ms: searchOutcome?.profile?.durationsMs.resolveRoots,
+        phase_rg_ms: searchOutcome?.profile?.durationsMs.rgSearch,
+        phase_root_filter_ms: searchOutcome?.profile?.durationsMs.rootFilter,
+        phase_context_filter_ms: searchOutcome?.profile?.durationsMs.contextFilter,
+        payload_bytes_estimate: searchOutcome?.profile?.serializedBytes,
         error: searchError,
       };
     }
@@ -157,7 +181,14 @@ export function registerCommonHandlers(handler: MessageHandler, deps: CommonHand
       deps.postMessage({ type: 'searchHistory', entries: deps.stateStore.getSearchHistory() });
     }
 
-    deps.postMessage({ type: 'searchResults', results, maxResults: 10000, telemetry: lastSearchTelemetry });
+    deps.postMessage({
+      type: 'searchResults',
+      results,
+      maxResults: effectiveMaxResults,
+      requestId: msg.requestId,
+      profile: searchOutcome?.profile,
+      telemetry: lastSearchTelemetry,
+    });
   });
 
   handler.registerHandler('__test_clearSearchHistory', async () => {

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -45,9 +45,11 @@ export interface GetWorkspaceInfoMessage {
 
 export interface RunSearchMessage {
   type: 'runSearch';
+  requestId?: string;
   query: string;
   scope: SearchScope;
   options: SearchOptions;
+  maxResults?: number;
   queryRows?: number;
   directoryPath?: string;
   modulePath?: string;
@@ -235,6 +237,8 @@ export interface SearchResultsMessage {
   results: SearchResult[];
   activeIndex?: number;
   maxResults?: number;
+  requestId?: string;
+  profile?: unknown;
   lspMode?: LspSearchMode;
   lspInfo?: LspSearchInfo;
 }
@@ -276,8 +280,10 @@ export interface ValidationResultMessage {
 
 export interface ConfigMessage {
   type: 'config';
-  replaceKeybinding: string;
-  maxResults: number;
+  replaceKeybinding?: string;
+  maxResults?: number;
+  resultsShowCollapsed?: boolean;
+  profileSearch?: boolean;
 }
 
 export interface ShowReplaceMessage {

--- a/src/rgSearch.ts
+++ b/src/rgSearch.ts
@@ -28,6 +28,11 @@ type RipgrepMatchEvent = {
 
 type RipgrepJsonEvent = RipgrepMatchEvent | { type: string; data?: unknown };
 
+const PREVIEW_CONTEXT_BEFORE = 40;
+const PREVIEW_CONTEXT_AFTER = 160;
+const PREVIEW_MAX_CHARS = 260;
+const MAX_MATCH_RANGES_PER_RESULT = 24;
+
 export function getRipgrepCommandCandidates(): string[] {
   const exeName = process.platform === 'win32' ? 'rg.exe' : 'rg';
 
@@ -182,18 +187,28 @@ function mapMatchToResult(evt: RipgrepMatchEvent, workspaceFolders: readonly vsc
   const submatches = evt.data.submatches || [];
   if (submatches.length === 0) return null;
 
-  const leadingWhitespace = lineText.length - lineText.trimStart().length;
-  const preview = lineText.trim();
-
-  const previewMatchRanges = submatches.map((m) => {
-    const start = Math.max(0, m.start - leadingWhitespace);
-    const end = Math.max(0, m.end - leadingWhitespace);
-    return { start, end };
-  });
-
-  const matchRanges = submatches.map((m) => ({ start: m.start, end: m.end }));
-
   const first = submatches[0];
+  const previewStart = Math.max(0, first.start - PREVIEW_CONTEXT_BEFORE);
+  const requestedPreviewEnd = Math.max(first.end + PREVIEW_CONTEXT_AFTER, previewStart + 1);
+  const previewEnd = Math.min(lineText.length, Math.min(previewStart + PREVIEW_MAX_CHARS, requestedPreviewEnd));
+
+  const preview = lineText.slice(previewStart, previewEnd);
+
+  const limitedMatchRanges = submatches
+    .slice(0, MAX_MATCH_RANGES_PER_RESULT)
+    .map((m) => ({ start: m.start, end: m.end }));
+
+  const previewMatchRanges = limitedMatchRanges
+    .filter((m) => m.end > previewStart && m.start < previewEnd)
+    .map((m) => ({
+      start: Math.max(0, m.start - previewStart),
+      end: Math.max(0, Math.min(preview.length, m.end - previewStart)),
+    }));
+
+  const firstPreviewRange = previewMatchRanges[0] || {
+    start: Math.max(0, first.start - previewStart),
+    end: Math.max(0, Math.min(preview.length, first.end - previewStart)),
+  };
 
   return {
     uri: vscode.Uri.file(filePath).toString(),
@@ -203,9 +218,10 @@ function mapMatchToResult(evt: RipgrepMatchEvent, workspaceFolders: readonly vsc
     character: first.start,
     length: Math.max(0, first.end - first.start),
     preview,
-    previewMatchRange: previewMatchRanges[0],
+    matchCount: submatches.length,
+    previewMatchRange: firstPreviewRange,
     previewMatchRanges,
-    matchRanges
+    matchRanges: limitedMatchRanges
   };
 }
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -78,10 +78,44 @@ export interface SearchOutcome {
   timedOut: boolean;
   cancelled: boolean;
   resultCapHit: boolean;
+  profile?: SearchProfile;
+}
+
+export interface SearchProfile {
+  requestId?: string;
+  scope: SearchScope;
+  queryLength: number;
+  rootCount: number;
+  serializedBytes: number;
+  resultsBeforeContextFilter: number;
+  resultsAfterContextFilter: number;
+  durationsMs: {
+    resolveRoots: number;
+    rgSearch: number;
+    rootFilter: number;
+    contextFilter: number;
+    total: number;
+  };
 }
 
 const SEARCH_TIMEOUT_MS = 5000;
 const DIRECTORY_SCOPE_MIN_QUERY_LENGTH = 3;
+
+function estimateSearchPayloadBytes(results: SearchResult[]): number {
+  let bytes = 0;
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    bytes += (r.uri?.length || 0) + (r.fileName?.length || 0) + (r.relativePath?.length || 0) + (r.preview?.length || 0);
+    bytes += 48;
+    if (Array.isArray(r.matchRanges)) {
+      bytes += r.matchRanges.length * 16;
+    }
+    if (Array.isArray(r.previewMatchRanges)) {
+      bytes += r.previewMatchRanges.length * 16;
+    }
+  }
+  return bytes;
+}
 
 export async function performSearch(
   query: string,
@@ -90,8 +124,10 @@ export async function performSearch(
   directoryPath?: string,
   modulePath?: string,
   maxResults: number = 10000,
-  smartExcludesEnabled: boolean = true
+  smartExcludesEnabled: boolean = true,
+  requestId?: string
 ): Promise<SearchOutcome> {
+  const searchStartedAt = Date.now();
   if (!query.trim() || query.length < 2) {
     return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
@@ -124,7 +160,9 @@ export async function performSearch(
   }
 
   const effectiveMaxResults = Math.max(1, Math.floor(maxResults || 10000));
+  const resolveRootsStartedAt = Date.now();
   const rootSpecs = await resolveSearchRoots(scope, directoryPath, modulePath);
+  const resolveRootsDurationMs = Date.now() - resolveRootsStartedAt;
   if (rootSpecs.length === 0) {
     return { results: [], timedOut: false, cancelled: false, resultCapHit: false };
   }
@@ -157,15 +195,40 @@ export async function performSearch(
   }, SEARCH_TIMEOUT_MS);
 
   try {
+    const rgStartedAt = Date.now();
     const rawResults = await promise;
+    const rgDurationMs = Date.now() - rgStartedAt;
     clearTimeout(timeoutId);
+
+    const rootFilterStartedAt = Date.now();
     const results = filterResultsToRoots(rawResults, rootSpecs);
+    const rootFilterDurationMs = Date.now() - rootFilterStartedAt;
+
+    const contextFilterStartedAt = Date.now();
     const filteredResults = await filterResultsByCodeContext(results, options);
+    const contextFilterDurationMs = Date.now() - contextFilterStartedAt;
+
     resultCapHit = rawResults.length >= effectiveMaxResults;
     if (activeSearchCancel === cancelForNewSearch) {
       activeSearchCancel = undefined;
     }
-    return { results: filteredResults, timedOut, cancelled, resultCapHit };
+    const profile: SearchProfile = {
+      requestId,
+      scope,
+      queryLength: query.length,
+      rootCount: rootSpecs.length,
+      serializedBytes: estimateSearchPayloadBytes(filteredResults),
+      resultsBeforeContextFilter: results.length,
+      resultsAfterContextFilter: filteredResults.length,
+      durationsMs: {
+        resolveRoots: resolveRootsDurationMs,
+        rgSearch: rgDurationMs,
+        rootFilter: rootFilterDurationMs,
+        contextFilter: contextFilterDurationMs,
+        total: Date.now() - searchStartedAt,
+      },
+    };
+    return { results: filteredResults, timedOut, cancelled, resultCapHit, profile };
   } catch (error) {
     clearTimeout(timeoutId);
     if (activeSearchCancel === cancelForNewSearch) {

--- a/src/services/PanelManager.ts
+++ b/src/services/PanelManager.ts
@@ -18,6 +18,17 @@ export class PanelManager {
   private _messageHandler?: MessageHandler;
   private _handlerConfigurator?: (handler: MessageHandler) => void;
 
+  private sanitizeSavedState(state: MinimizeMessage['state'] | undefined): MinimizeMessage['state'] | undefined {
+    if (!state) {
+      return undefined;
+    }
+    const sanitized = { ...state } as MinimizeMessage['state'] & Record<string, unknown>;
+    delete sanitized.results;
+    delete sanitized.lastPreview;
+    delete sanitized.lspResultsCache;
+    return sanitized;
+  }
+
   constructor(
     private context: vscode.ExtensionContext,
     private extensionUri: vscode.Uri,
@@ -32,7 +43,7 @@ export class PanelManager {
     if (persist) {
       const persistedState = store.get<MinimizeMessage['state']>('rifler.persistedSearchState');
       if (persistedState) {
-        this.stateStore.setSavedState(persistedState);
+        this.stateStore.setSavedState(this.sanitizeSavedState(persistedState));
       }
     }
   }
@@ -169,7 +180,7 @@ export class PanelManager {
    */
   minimize(state?: MinimizeMessage['state']): void {
     // Save the state before closing
-    this.stateStore.setSavedState(state);
+    this.stateStore.setSavedState(this.sanitizeSavedState(state));
 
     // Hide the panel
     if (this.currentPanel) {
@@ -270,6 +281,7 @@ export class PanelManager {
     const replaceKeybinding = config.get<string>('replaceInPreviewKeybinding', 'ctrl+shift+r');
     const maxResults = config.get<number>('maxResults', 10000);
     const resultsShowCollapsed = config.get<boolean>('results.showCollapsed', false);
+    const profileSearch = config.get<boolean>('debug.profileSearch', false);
     const contextDefaults = {
       includeCode: config.get<boolean>('searchContext.includeCode', true),
       includeComments: config.get<boolean>('searchContext.includeComments', true),
@@ -285,6 +297,7 @@ export class PanelManager {
       replaceKeybinding,
       maxResults,
       resultsShowCollapsed,
+      profileSearch,
       contextDefaults
     });
 

--- a/src/sidebar/SidebarProvider.ts
+++ b/src/sidebar/SidebarProvider.ts
@@ -59,6 +59,36 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
   private _suppressSideEffectsUntil = 0;
   private _shouldSaveOnNextHide = false;
   private _lastVisibility?: boolean;
+  private _lastRestoreAt = 0;
+  private _didInitialRestore = false;
+
+  private _sanitizeStateForPersistence(state: Record<string, unknown> | undefined): SidebarState | undefined {
+    if (!state) {
+      return undefined;
+    }
+
+    const sanitized = { ...state } as Record<string, unknown>;
+    if (typeof sanitized['query'] === 'string' && (sanitized['query'] as string).length > 2000) {
+      sanitized['query'] = (sanitized['query'] as string).slice(0, 2000);
+    }
+    if (typeof sanitized['replaceText'] === 'string' && (sanitized['replaceText'] as string).length > 2000) {
+      sanitized['replaceText'] = (sanitized['replaceText'] as string).slice(0, 2000);
+    }
+    delete sanitized.results;
+    delete sanitized.lastPreview;
+    delete sanitized.lspResultsCache;
+
+    return sanitized as unknown as SidebarState;
+  }
+
+  private _stateNeedsSanitizing(state: Record<string, unknown> | undefined): boolean {
+    if (!state) {
+      return false;
+    }
+    return Object.prototype.hasOwnProperty.call(state, 'results')
+      || Object.prototype.hasOwnProperty.call(state, 'lastPreview')
+      || Object.prototype.hasOwnProperty.call(state, 'lspResultsCache');
+  }
 
   public readonly viewType: string;
   private readonly _stateKey: string;
@@ -99,6 +129,7 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
   ): void | Thenable<void> {
     this._view = webviewView;
     this._webviewReady = false;
+    this._didInitialRestore = false;
     console.log(`Rifler ${this._logLabel} WebviewView resolved`);
 
     this._updateViewTitle();
@@ -165,7 +196,8 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
           });
         } else {
           // No selection: restore state and focus search input
-          if (!this._pendingInitOptions?.initialQuery) {
+          const now = Date.now();
+          if (this._webviewReady && !this._pendingInitOptions?.initialQuery && now - this._lastRestoreAt > 250) {
             this._restoreState();
           }
           webviewView.webview.postMessage({ type: 'focusSearch' });
@@ -200,10 +232,7 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
       })
     );
 
-    // Initial state restore if visible
-    if (webviewView.visible) {
-      this._restoreState();
-    }
+    // Initial state restore is handled on 'webviewReady' to avoid duplicate restore->search runs.
   }
 
   private _getSelectedText(): string | undefined {
@@ -278,14 +307,27 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
     switch (message.type) {
       case 'runSearch': {
         // Handle search locally to persist state after each search
-        const searchMessage = message as unknown as { query: string; scope: SearchScope; options: SearchOptions; directoryPath?: string; modulePath?: string; activeIndex?: number; smartExcludesEnabled?: boolean };
+        const searchMessage = message as unknown as {
+          query: string;
+          scope: SearchScope;
+          options: SearchOptions;
+          maxResults?: number;
+          directoryPath?: string;
+          modulePath?: string;
+          activeIndex?: number;
+          smartExcludesEnabled?: boolean;
+          requestId?: string;
+        };
         await this._runSearch(searchMessage);
         break;
       }
       case 'webviewReady': {
         this._webviewReady = true;
         // Restore persisted sidebar state first
-        this._restoreState();
+        if (!this._didInitialRestore) {
+          this._restoreState();
+          this._didInitialRestore = true;
+        }
         // Then apply pending initialization options (e.g. selection query) so they win over restored state
         if (this._pendingInitOptions) {
           const { initialQuery, showReplace } = this._pendingInitOptions;
@@ -327,8 +369,9 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
           const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
           const persist = cfg.get<boolean>('persistSearchState', true) && scope !== 'off';
           const store = scope === 'global' ? this._context.globalState : this._context.workspaceState;
+          const sanitizedState = this._sanitizeStateForPersistence(message.state as Record<string, unknown>);
           if (persist) {
-            await store.update(this._stateKey, message.state as unknown as SidebarState);
+            await store.update(this._stateKey, sanitizedState);
             console.log(`${this._logLabel}: state saved to ${this._stateKey}`);
           }
           // Resolve any pending save promise
@@ -338,29 +381,46 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
           }
         }
         break;
-      case 'clearState':
-        // Clear saved state when search is cleared
-        {
-          const cfg = vscode.workspace.getConfiguration('rifler');
-          const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
-          const store = scope === 'global' ? this._context.globalState : this._context.workspaceState;
-          await store.update(this._stateKey, undefined);
+      case 'clearState': {
+        // Avoid persistence clear churn right after restore/visibility transitions.
+        if (Date.now() - this._lastRestoreAt < 500) {
+          break;
         }
+        const cfg = vscode.workspace.getConfiguration('rifler');
+        const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
+        const store = scope === 'global' ? this._context.globalState : this._context.workspaceState;
+        await store.update(this._stateKey, undefined);
         break;
+      }
     }
   }
 
-  private async _runSearch(message: { query: string; scope: SearchScope; options: SearchOptions; directoryPath?: string; modulePath?: string; activeIndex?: number; smartExcludesEnabled?: boolean; queryRows?: number }): Promise<void> {
+  private async _runSearch(message: {
+    query: string;
+    scope: SearchScope;
+    options: SearchOptions;
+    directoryPath?: string;
+    modulePath?: string;
+    activeIndex?: number;
+    smartExcludesEnabled?: boolean;
+    queryRows?: number;
+    requestId?: string;
+    maxResults?: number;
+  }): Promise<void> {
     if (!message.query || !message.scope || !message.options) {
       return;
     }
+
+    const cfg = vscode.workspace.getConfiguration('rifler');
+    const configuredMaxResults = cfg.get<number>('maxResults', 10000);
+    const effectiveMaxResults = Math.max(1, Math.floor(message.maxResults ?? configuredMaxResults));
 
     if (message.scope === 'directory' && message.query.trim().length > 0 && message.query.trim().length < 3) {
       this._view?.webview.postMessage({
         type: 'error',
         message: 'Directory scope requires at least 3 characters.'
       });
-      this._view?.webview.postMessage({ type: 'searchResults', results: [], activeIndex: -1 });
+      this._view?.webview.postMessage({ type: 'searchResults', results: [], activeIndex: -1, maxResults: effectiveMaxResults });
       return;
     }
 
@@ -376,8 +436,9 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
         message.options,
         message.directoryPath,
         message.modulePath,
-        10000,
-        message.smartExcludesEnabled ?? true
+        effectiveMaxResults,
+        message.smartExcludesEnabled ?? true,
+        message.requestId
       );
       results = searchOutcome.results;
     } catch (error) {
@@ -406,9 +467,16 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
         include_strings: message.options.includeStrings ?? true,
         file_mask_count: (message.options.fileMask ? message.options.fileMask.split(/[;,]+/).filter(Boolean).length : 0),
         query_rows: message.queryRows ?? 1,
+        max_results: effectiveMaxResults,
         timed_out: timedOut,
         cancelled,
         result_cap_hit: resultCapHit,
+        request_id: message.requestId,
+        phase_resolve_roots_ms: searchOutcome?.profile?.durationsMs.resolveRoots,
+        phase_rg_ms: searchOutcome?.profile?.durationsMs.rgSearch,
+        phase_root_filter_ms: searchOutcome?.profile?.durationsMs.rootFilter,
+        phase_context_filter_ms: searchOutcome?.profile?.durationsMs.contextFilter,
+        payload_bytes_estimate: searchOutcome?.profile?.serializedBytes,
         error: searchError,
       });
     }
@@ -418,7 +486,10 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
     this._view?.webview.postMessage({
       type: 'searchResults',
       results,
-      activeIndex
+      activeIndex,
+      maxResults: effectiveMaxResults,
+      requestId: message.requestId,
+      profile: searchOutcome?.profile,
     });
 
     if (this.stateStore) {
@@ -446,21 +517,19 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
     }
 
     // Save search state for persistence
-    const cfg = vscode.workspace.getConfiguration('rifler');
     const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
     const persist = cfg.get<boolean>('persistSearchState', true) && scope !== 'off';
     const store = scope === 'global' ? this._context.globalState : this._context.workspaceState;
     if (persist) {
-      await store.update(this._stateKey, {
+      await store.update(this._stateKey, this._sanitizeStateForPersistence({
         query: message.query,
         scope: message.scope,
         options: message.options,
         queryRows: message.queryRows,
         directoryPath: message.directoryPath,
         modulePath: message.modulePath,
-        results: results,
         activeIndex
-      });
+      }));
     }
   }
 
@@ -704,7 +773,6 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
       if (persist) {
         await store.update(this._stateKey, {
           ...existing,
-          lastPreview: payload,
           activeIndex: activeIndex ?? existing.activeIndex ?? 0
         });
       }
@@ -886,15 +954,22 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
     const cfg = vscode.workspace.getConfiguration('rifler');
     const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
     const store = scope === 'global' ? this._context.globalState : this._context.workspaceState;
-    const state = store.get(this._stateKey);
+    const state = store.get(this._stateKey) as SidebarState | undefined;
+    const shouldSanitize = this._stateNeedsSanitizing(state as unknown as Record<string, unknown> | undefined);
+    const sanitizedState = this._sanitizeStateForPersistence(state as unknown as Record<string, unknown> | undefined);
+    if (shouldSanitize) {
+      void store.update(this._stateKey, sanitizedState);
+    }
 
     this._updateViewTitle();
 
     if (this._view) {
+      this._lastRestoreAt = Date.now();
       // Send configuration to webview
       const replaceKeybinding = cfg.get<string>('replaceInPreviewKeybinding', 'ctrl+shift+r');
       const maxResults = cfg.get<number>('maxResults', 10000);
       const resultsShowCollapsed = cfg.get<boolean>('results.showCollapsed', false);
+      const profileSearch = cfg.get<boolean>('debug.profileSearch', false);
       const contextDefaults = {
         includeCode: cfg.get<boolean>('searchContext.includeCode', true),
         includeComments: cfg.get<boolean>('searchContext.includeComments', true),
@@ -906,15 +981,16 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
         replaceKeybinding,
         maxResults,
         resultsShowCollapsed,
+        profileSearch,
         contextDefaults
       });
 
-      console.log(`${this._logLabel}._restoreState: state =`, state ? 'exists' : 'undefined', state);
-      if (state) {
+      console.log(`${this._logLabel}._restoreState: state =`, sanitizedState ? 'exists' : 'undefined', sanitizedState);
+      if (sanitizedState) {
         console.log(`${this._logLabel}._restoreState: sending restoreState message`);
         this._view.webview.postMessage({
           type: 'restoreState',
-          state
+          state: sanitizedState
         });
       } else {
         console.log(`${this._logLabel}._restoreState: no state to restore, sending clearState`);
@@ -1034,9 +1110,12 @@ export class RiflerSidebarProvider implements vscode.WebviewViewProvider {
   public sendConfigUpdate(resultsShowCollapsed: boolean): void {
     this._updateViewTitle();
     if (this._view) {
+      const cfg = vscode.workspace.getConfiguration('rifler');
+      const profileSearch = cfg.get<boolean>('debug.profileSearch', false);
       this._view.webview.postMessage({
         type: 'config',
-        resultsShowCollapsed
+        resultsShowCollapsed,
+        profileSearch
       });
     }
   }

--- a/src/state/StateStore.ts
+++ b/src/state/StateStore.ts
@@ -37,6 +37,27 @@ export class StateStore {
   private visibilityCallbacks: Array<(visible: boolean) => void> = [];
   private bottomVisibilityCallbacks: Array<(visible: boolean) => void> = [];
 
+  private sanitizePersistedState(state: MinimizeMessage['state'] | undefined): MinimizeMessage['state'] | undefined {
+    if (!state) {
+      return undefined;
+    }
+    const sanitized = { ...state } as MinimizeMessage['state'] & Record<string, unknown>;
+    delete sanitized.results;
+    delete sanitized.lastPreview;
+    delete sanitized.lspResultsCache;
+    return sanitized;
+  }
+
+  private stateNeedsSanitizing(state: MinimizeMessage['state'] | undefined): boolean {
+    if (!state) {
+      return false;
+    }
+    const raw = state as unknown as Record<string, unknown>;
+    return Object.prototype.hasOwnProperty.call(raw, 'results')
+      || Object.prototype.hasOwnProperty.call(raw, 'lastPreview')
+      || Object.prototype.hasOwnProperty.call(raw, 'lspResultsCache');
+  }
+
   constructor(private readonly context: vscode.ExtensionContext) {
     const cfg = vscode.workspace.getConfiguration('rifler');
     const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
@@ -45,7 +66,10 @@ export class StateStore {
     if (persist) {
       const persisted = store.get<MinimizeMessage['state']>('rifler.persistedSearchState');
       if (persisted) {
-        this.savedState = persisted;
+        this.savedState = this.sanitizePersistedState(persisted);
+        if (this.stateNeedsSanitizing(persisted)) {
+          store.update('rifler.persistedSearchState', this.savedState);
+        }
       }
       
       // Load preview panel collapsed state - default to expanded (false)
@@ -148,13 +172,13 @@ export class StateStore {
   }
 
   setSavedState(state: MinimizeMessage['state'] | undefined): void {
-    this.savedState = state;
+    this.savedState = this.sanitizePersistedState(state);
     const cfg = vscode.workspace.getConfiguration('rifler');
     const scope = cfg.get<'workspace' | 'global' | 'off'>('persistenceScope', 'workspace');
     const persist = cfg.get<boolean>('persistSearchState', true) && scope !== 'off';
     const store = scope === 'global' ? this.context.globalState : this.context.workspaceState;
     if (persist) {
-      store.update('rifler.persistedSearchState', state);
+      store.update('rifler.persistedSearchState', this.savedState);
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,6 +24,7 @@ export interface SearchResult {
   character: number;
   length: number;
   preview: string;
+  matchCount?: number;
   previewMatchRange: {
     start: number;
     end: number;

--- a/src/views/ViewManager.ts
+++ b/src/views/ViewManager.ts
@@ -20,6 +20,17 @@ export class ViewManager {
   private static readonly RIFLER_VIEWLET_ID = 'workbench.view.extension.rifler-sidebar';
   private static readonly DEFAULT_SIDEBAR_COMMAND = 'workbench.view.explorer';
 
+  private _sanitizeSavedState(state: MinimizeMessage['state'] | undefined): MinimizeMessage['state'] | undefined {
+    if (!state) {
+      return undefined;
+    }
+    const sanitized = { ...state } as MinimizeMessage['state'] & Record<string, unknown>;
+    delete sanitized.results;
+    delete sanitized.lastPreview;
+    delete sanitized.lspResultsCache;
+    return sanitized;
+  }
+
   constructor(context: vscode.ExtensionContext) {
     this._context = context;
     this._lastNonRiflerSidebarCommand =
@@ -248,6 +259,7 @@ export class ViewManager {
     } else if (this._stateStore) {
       savedState = this._stateStore.getSavedState();
     }
+    savedState = this._sanitizeSavedState(savedState);
     
     // Close current view
     if (currentLocation === 'sidebar') {

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -77,7 +77,17 @@ console.log('[Rifler] Webview script starting...');
     lspSubMode: 'references', // 'references' | 'definitions' | 'implementations' | 'typeDefinitions'
     lspInfo: null, // { languageId, symbolName, confidence }
     lspResultsCache: {}, // Cache results per LSP type: { references: {...}, definitions: {...}, ... }
-    lastTextQuery: ''
+    lastTextQuery: '',
+    searchRequestSeq: 0,
+    lastSentRequestId: null,
+    lastHandledRequestId: null,
+    inFlightSearches: new Set(),
+    profilingEnabled: false,
+    lastSearchProfile: null,
+    testMode: false,
+    pendingSearchResultsMessage: null,
+    resultsProcessScheduled: false,
+    previewWindows: Object.create(null)
   };
 
     let pendingTestHistoryEcho = false;
@@ -1870,7 +1880,9 @@ console.log('[Rifler] Webview script starting...');
   }
 
   queryInput.addEventListener('input', () => {
-    console.log('Input event triggered, value:', queryInput.value);
+    if (state.profilingEnabled) {
+      console.log('Input event triggered, value:', queryInput.value);
+    }
     clearTimeout(state.searchTimeout);
     recomputeMultilineOption({ skipSearch: true });
     updateReplaceActionState();
@@ -1913,10 +1925,14 @@ console.log('[Rifler] Webview script starting...');
     }, 300);
 
     state.searchTimeout = setTimeout(() => {
-      console.log('Timeout fired, calling runSearch()');
+      if (state.profilingEnabled) {
+        console.log('Timeout fired, calling runSearch()');
+      }
       runSearch();
     }, 300);
-    console.log('Timeout set, id:', state.searchTimeout);
+    if (state.profilingEnabled) {
+      console.log('Timeout set, id:', state.searchTimeout);
+    }
   });
 
   if (matchCaseToggle) {
@@ -2061,12 +2077,9 @@ console.log('[Rifler] Webview script starting...');
         queryRows: state.queryRows,
         showReplace: replaceRow.classList.contains('visible'),
         smartExcludesEnabled: state.smartExcludesEnabled,
-        results: state.results,
         activeIndex: state.activeIndex,
-        lastPreview: state.lastPreview,
         searchMode: state.searchMode,
-        lspSubMode: state.lspSubMode,
-        lspResultsCache: state.lspResultsCache
+        lspSubMode: state.lspSubMode
       }
     });
   }
@@ -2523,7 +2536,18 @@ console.log('[Rifler] Webview script starting...');
     }
     
     const message = event.data;
-    console.log('Webview received message:', message.type, message);
+    if (message && typeof message.type === 'string' && message.type.startsWith('__test_')) {
+      state.testMode = true;
+    }
+    if (message.type === 'searchResults') {
+      const count = Array.isArray(message.results) ? message.results.length : 0;
+      const occurrences = Array.isArray(message.results)
+        ? message.results.reduce((sum, r) => sum + getResultOccurrenceCount(r), 0)
+        : 0;
+      console.log('Webview received message: searchResults', { requestId: message.requestId, count, occurrences });
+    } else {
+      console.log('Webview received message:', message.type);
+    }
     switch (message.type) {
       case 'searchHistory':
         console.log('[Rifler] Received searchHistory update:', message.entries);
@@ -2545,8 +2569,8 @@ console.log('[Rifler] Webview script starting...');
           // Ignore late LSP results after switching back to text mode
           break;
         }
-        if (message.maxResults) {
-          state.maxResultsCap = message.maxResults;
+        if (typeof message.maxResults === 'number' && Number.isFinite(message.maxResults)) {
+          state.maxResultsCap = Math.max(1, Math.floor(message.maxResults));
         }
         if (message.lspInfo) {
           // Check if symbol changed - if so, clear cache
@@ -2571,7 +2595,7 @@ console.log('[Rifler] Webview script starting...');
             console.log('[Rifler] Cached LSP results for', state.lspSubMode, 'symbol:', message.lspInfo.symbolName);
           }
         }
-        handleSearchResults(message.results, { skipAutoLoad: false, activeIndex: message.activeIndex });
+        handleSearchResultsMessage(message);
         break;
       case 'modulesList':
         handleModulesList(message.modules);
@@ -2618,8 +2642,8 @@ console.log('[Rifler] Webview script starting...');
         if (message.replaceKeybinding) {
           state.replaceKeybinding = message.replaceKeybinding;
         }
-        if (message.maxResults) {
-          state.maxResultsCap = message.maxResults;
+        if (typeof message.maxResults === 'number' && Number.isFinite(message.maxResults)) {
+          state.maxResultsCap = Math.max(1, Math.floor(message.maxResults));
         }
         if (typeof message.resultsShowCollapsed === 'boolean') {
           state.resultsShowCollapsed = message.resultsShowCollapsed;
@@ -2634,6 +2658,9 @@ console.log('[Rifler] Webview script starting...');
             state.options.includeStrings = state.contextDefaults.includeStrings;
           }
           applyContextDefaults();
+        }
+        if (typeof message.profileSearch === 'boolean') {
+          state.profilingEnabled = message.profileSearch;
         }
         break;
       case 'focusSearch':
@@ -3343,6 +3370,9 @@ console.log('[Rifler] Webview script starting...');
 
     const patterns = [];
     state.projectExclusions.forEach(project => {
+      if (project && project.enabled === false) {
+        return;
+      }
       patterns.push(...project.excludePatterns);
     });
 
@@ -3363,6 +3393,20 @@ console.log('[Rifler] Webview script starting...');
   }
 
   // Helper function to update results count display
+  function getResultOccurrenceCount(result) {
+    if (!result) return 0;
+    if (typeof result.matchCount === 'number' && Number.isFinite(result.matchCount)) {
+      return Math.max(1, Math.floor(result.matchCount));
+    }
+    if (Array.isArray(result.matchRanges) && result.matchRanges.length > 0) {
+      return result.matchRanges.length;
+    }
+    if (Array.isArray(result.previewMatchRanges) && result.previewMatchRanges.length > 0) {
+      return result.previewMatchRanges.length;
+    }
+    return 1;
+  }
+
   function updateResultsCountDisplay(results) {
     if (!resultsCountText) return;
     
@@ -3377,9 +3421,10 @@ console.log('[Rifler] Webview script starting...');
       resultsCountText.textContent = 'No results found';
     } else {
       const uniqueFiles = new Set(results.map(r => r.uri)).size;
-      const isCapped = state.maxResultsCap && results.length >= state.maxResultsCap;
+      const totalOccurrences = results.reduce((sum, r) => sum + getResultOccurrenceCount(r), 0);
+      const isCapped = state.maxResultsCap && totalOccurrences >= state.maxResultsCap;
       const suffix = isCapped ? '+' : '';
-      let text = `${results.length}${suffix} result${results.length !== 1 ? 's' : ''} in ${uniqueFiles} file${uniqueFiles !== 1 ? 's' : ''}`;
+      let text = `${totalOccurrences}${suffix} result${totalOccurrences !== 1 ? 's' : ''} in ${uniqueFiles} file${uniqueFiles !== 1 ? 's' : ''}`;
       
       if (state.lastSearchDuration > 0) {
         text += ` (${state.lastSearchDuration.toFixed(2)}s)`;
@@ -3395,6 +3440,35 @@ console.log('[Rifler] Webview script starting...');
       resultsCountText.textContent = 'Type to search...';
       resultsCountText.style.opacity = '1';
     }
+  }
+
+  function getPreviewWindowForUri(uri, lineCount, activeLineStart, activeLineEnd) {
+    const DEFAULT_RADIUS = 120;
+    const prev = state.previewWindows && uri ? state.previewWindows[uri] : null;
+    const radius = prev && typeof prev.radius === 'number' ? prev.radius : DEFAULT_RADIUS;
+
+    const clampedStart = Math.max(0, Math.min(lineCount - 1, activeLineStart));
+    const clampedEnd = Math.max(clampedStart, Math.min(lineCount - 1, activeLineEnd));
+
+    const start = Math.max(0, clampedStart - radius);
+    const end = Math.min(lineCount - 1, clampedEnd + radius);
+
+    return {
+      start,
+      end,
+      radius,
+      hasTopMore: start > 0,
+      hasBottomMore: end < lineCount - 1,
+    };
+  }
+
+  function setPreviewWindowRadius(uri, radius) {
+    if (!uri) return;
+    if (!state.previewWindows) {
+      state.previewWindows = Object.create(null);
+    }
+    const current = state.previewWindows[uri] || { radius: 120 };
+    state.previewWindows[uri] = { ...current, radius: Math.max(120, radius) };
   }
 
   function scheduleVirtualRender() {
@@ -3547,7 +3621,9 @@ console.log('[Rifler] Webview script starting...');
         : queryInput.value.trim();
       state.currentQuery = query;
       
-      console.log('runSearch called, query:', query, 'length:', query.length, 'useRegex:', state.options.useRegex);
+      if (state.profilingEnabled) {
+        console.log('runSearch called, query:', query, 'length:', query.length, 'useRegex:', state.options.useRegex);
+      }
       
       if (state.currentScope === 'directory' && query.trim().length > 0 && query.trim().length < 3) {
         showPlaceholder('Directory scope needs at least 3 characters...');
@@ -3574,24 +3650,31 @@ console.log('[Rifler] Webview script starting...');
       showPlaceholder('Searching...');
       clearResultsCountDisplay();
       state.searchStartTime = performance.now();
+      const requestId = 's-' + Date.now() + '-' + (++state.searchRequestSeq);
+      state.lastSentRequestId = requestId;
+      state.inFlightSearches.add(requestId);
 
       const message = {
         type: 'runSearch',
+        requestId,
         query: query,
         scope: state.currentScope,
+        maxResults: state.maxResultsCap,
         options: { ...state.options },
         queryRows: state.queryRows,
         smartExcludesEnabled: state.smartExcludesEnabled,
         exclusionPatterns: getActiveExcludePatterns()
       };
 
-      console.log('[Rifler Webview] Search state:', {
-        query,
-        queryRows: state.queryRows,
-        multiline: state.options.multiline,
-        hasNewline: query.includes('\n'),
-        lineCount: query.split('\n').length
-      });
+      if (state.profilingEnabled) {
+        console.log('[Rifler Webview] Search state:', {
+          query,
+          queryRows: state.queryRows,
+          multiline: state.options.multiline,
+          hasNewline: query.includes('\n'),
+          lineCount: query.split('\n').length
+        });
+      }
 
       if (state.currentScope === 'directory') {
         message.directoryPath = directoryInput.value.trim();
@@ -3600,8 +3683,9 @@ console.log('[Rifler] Webview script starting...');
         message.modulePath = moduleSelect.value;
       }
 
-      console.log('Sending search message:', message);
-      console.log('[Rifler Webview] Search payload:', JSON.stringify(message));
+      if (state.profilingEnabled) {
+        console.log('Sending search message:', { requestId, queryLength: query.length, scope: state.currentScope, maxResults: state.maxResultsCap });
+      }
       vscode.postMessage(message);
     } catch (error) {
       console.error('Error in runSearch:', error);
@@ -3635,17 +3719,23 @@ console.log('[Rifler] Webview script starting...');
     }
 
     // Group results by file
-    const groups = [];
-    const fileMap = new Map();
-    results.forEach((result, index) => {
-      const path = result.relativePath || result.fileName;
-      if (!fileMap.has(path)) {
-        const group = { path, fileName: path.split(/[\\/]/).pop(), matches: [] };
-        fileMap.set(path, group);
-        groups.push(group);
-      }
-      fileMap.get(path).matches.push({ ...result, originalIndex: index });
-    });
+      const groups = [];
+      const fileMap = new Map();
+      const indexByPath = new Map();
+      results.forEach((result, index) => {
+        const path = result.relativePath || result.fileName;
+        if (!fileMap.has(path)) {
+          const group = { path, fileName: path.split(/[\\/]/).pop(), matchIndexes: [], occurrenceCount: 0 };
+          fileMap.set(path, group);
+          indexByPath.set(path, groups.length);
+          groups.push(group);
+        }
+        const groupIdx = indexByPath.get(path);
+        if (groupIdx !== undefined) {
+          groups[groupIdx].matchIndexes.push(index);
+          groups[groupIdx].occurrenceCount += getResultOccurrenceCount(result);
+        }
+      });
 
     state.renderItems = [];
     let cumulativeTop = 0;
@@ -3669,7 +3759,7 @@ console.log('[Rifler] Webview script starting...');
         type: 'fileHeader',
         path: group.path,
         fileName: group.fileName,
-        matchCount: group.matches.length,
+        matchCount: group.occurrenceCount,
         isCollapsed: isCollapsed,
         top: cumulativeTop,
         height: 40
@@ -3678,23 +3768,23 @@ console.log('[Rifler] Webview script starting...');
       
       if (!isCollapsed) {
         // For files with more than 5 results, use a scrollable group container
-        if (group.matches.length > 5) {
+        if (group.matchIndexes.length > 5) {
           state.renderItems.push({
             type: 'matchesGroup',
             path: group.path,
-            matches: group.matches,
+            matchIndexes: group.matchIndexes,
             top: cumulativeTop,
             height: 150
           });
           cumulativeTop += 150;
         } else {
-          group.matches.forEach((match, matchIdx) => {
+          group.matchIndexes.forEach((originalIndex, matchIdx) => {
             state.renderItems.push({
               type: 'match',
-              ...match,
+              originalIndex,
               isFirstInGroup: matchIdx === 0,
-              isLastInGroup: matchIdx === group.matches.length - 1,
-              groupSize: group.matches.length,
+              isLastInGroup: matchIdx === group.matchIndexes.length - 1,
+              groupSize: group.matchIndexes.length,
               groupPath: group.path,
               top: cumulativeTop,
               height: 28
@@ -3720,7 +3810,9 @@ console.log('[Rifler] Webview script starting...');
       virtualContent.style.height = totalHeight;
     }
 
-    console.log('[Rifler] renderItems populated:', state.renderItems.length, 'items');
+    if (state.profilingEnabled) {
+      console.log('[Rifler] renderItems populated:', state.renderItems.length, 'items');
+    }
     updateResultsCountDisplay(results);
     if (collapseAllBtn) {
       collapseAllBtn.style.display = results.length > 0 ? 'flex' : 'none';
@@ -3729,7 +3821,9 @@ console.log('[Rifler] Webview script starting...');
       }
     }
 
-    vscode.postMessage({ type: '__test_searchCompleted', results: results });
+    if (state.testMode) {
+      vscode.postMessage({ type: '__test_searchCompleted', results: results });
+    }
 
     if (results.length === 0) {
       showPlaceholder('No results found');
@@ -3743,12 +3837,14 @@ console.log('[Rifler] Webview script starting...');
 
     hidePlaceholder();
 
-    // Auto-load first result if available
-    if (hasResults && state.activeIndex < 0) {
+    const shouldAutoLoadPreview = hasResults && !options.skipAutoLoad && results.length <= 1200;
+
+    // Auto-load first result only for manageable result sets
+    if (shouldAutoLoadPreview && state.activeIndex < 0) {
       state.activeIndex = 0;
       applyPreviewHeight(previewHeight || getDefaultPreviewHeight(), { updateLastExpanded: false, persist: false, visible: true });
       setActiveIndex(0, { skipLoad: false });
-    } else if (hasResults && state.activeIndex >= 0) {
+    } else if (shouldAutoLoadPreview && state.activeIndex >= 0) {
       applyPreviewHeight(previewHeight || getDefaultPreviewHeight(), { updateLastExpanded: false, persist: false, visible: true });
       setActiveIndex(state.activeIndex, { skipLoad: !!options.skipAutoLoad });
     } else {
@@ -3766,6 +3862,59 @@ console.log('[Rifler] Webview script starting...');
     }
   }
 
+  function handleSearchResultsMessage(message) {
+    const requestId = typeof message.requestId === 'string' ? message.requestId : null;
+    if (requestId) {
+      state.inFlightSearches.delete(requestId);
+    }
+
+    if (requestId && state.lastSentRequestId && requestId !== state.lastSentRequestId) {
+      if (state.profilingEnabled) {
+        console.log('[Rifler][Profile] Dropping stale search response', {
+          requestId,
+          expected: state.lastSentRequestId,
+          results: Array.isArray(message.results) ? message.results.length : 0,
+        });
+      }
+      return;
+    }
+
+    state.lastHandledRequestId = requestId;
+    state.pendingSearchResultsMessage = message;
+
+    if (state.resultsProcessScheduled) {
+      return;
+    }
+
+    state.resultsProcessScheduled = true;
+    requestAnimationFrame(() => {
+      state.resultsProcessScheduled = false;
+      const pending = state.pendingSearchResultsMessage;
+      state.pendingSearchResultsMessage = null;
+      if (!pending) {
+        return;
+      }
+
+      const startedAt = performance.now();
+      handleSearchResults(pending.results || [], { skipAutoLoad: false, activeIndex: pending.activeIndex });
+      const renderMs = performance.now() - startedAt;
+
+      const profile = pending.profile;
+      state.lastSearchProfile = profile || null;
+    if (state.profilingEnabled) {
+      console.log('[Rifler][Profile] Search pipeline', {
+        requestId: pending.requestId,
+        queryLength: profile?.queryLength,
+        roots: profile?.rootCount,
+        resultCount: (pending.results || []).length,
+        payloadBytesEstimate: profile?.serializedBytes,
+        backend: profile?.durationsMs,
+        webviewRenderMs: Number(renderMs.toFixed(2)),
+      });
+    }
+    });
+  }
+
   // ========================================================================
   // Incremental expand/collapse — patch renderItems in-place
   // ========================================================================
@@ -3775,32 +3924,35 @@ console.log('[Rifler] Webview script starting...');
    * Uses the same logic as handleSearchResults but for a single group.
    */
   function buildMatchItemsForPath(filePath) {
-    const matches = [];
+    const matchIndexes = [];
+    let occurrenceCount = 0;
     state.results.forEach((r, idx) => {
       const p = r.relativePath || r.fileName;
       if (p === filePath) {
-        matches.push({ ...r, originalIndex: idx });
+        matchIndexes.push(idx);
+        occurrenceCount += getResultOccurrenceCount(r);
       }
     });
-    if (matches.length === 0) return [];
+    if (matchIndexes.length === 0) return [];
 
     const items = [];
-    if (matches.length > 5) {
+    if (matchIndexes.length > 5) {
       items.push({
         type: 'matchesGroup',
         path: filePath,
-        matches: matches,
+        matchIndexes,
+        matchCount: occurrenceCount,
         top: 0,
         height: 150
       });
     } else {
-      matches.forEach((match, matchIdx) => {
+      matchIndexes.forEach((originalIndex, matchIdx) => {
         items.push({
           type: 'match',
-          ...match,
+          originalIndex,
           isFirstInGroup: matchIdx === 0,
-          isLastInGroup: matchIdx === matches.length - 1,
-          groupSize: matches.length,
+          isLastInGroup: matchIdx === matchIndexes.length - 1,
+          groupSize: matchIndexes.length,
           groupPath: filePath,
           top: 0,
           height: 28
@@ -4115,13 +4267,15 @@ console.log('[Rifler] Webview script starting...');
         if (target && target.classList.contains('file-name')) {
           e.stopPropagation();
           // Find the first match for this file and open it in the editor
-          const resultIndex = state.results.findIndex((r) => {
-            const path = r.relativePath || r.fileName;
-            return path === itemData.path;
-          });
-          if (resultIndex !== -1) {
-            setActiveIndex(resultIndex);
-            openResultInEditor(resultIndex);
+          const firstIndex = Array.isArray(itemData.matchIndexes) && itemData.matchIndexes.length > 0
+            ? itemData.matchIndexes[0]
+            : state.results.findIndex((r) => {
+              const path = r.relativePath || r.fileName;
+              return path === itemData.path;
+            });
+          if (firstIndex !== -1) {
+            setActiveIndex(firstIndex);
+            openResultInEditor(firstIndex);
           }
           return;
         }
@@ -4156,8 +4310,8 @@ console.log('[Rifler] Webview script starting...');
       groupContainer.style.position = 'relative';
 
       const MATCH_HEIGHT = 28;
-      const matches = itemData.matches;
-      const totalGroupHeight = matches.length * MATCH_HEIGHT;
+      const matchIndexes = itemData.matchIndexes || [];
+      const totalGroupHeight = matchIndexes.length * MATCH_HEIGHT;
 
       // Spacer element to maintain scrollable height
       const spacer = document.createElement('div');
@@ -4173,7 +4327,7 @@ console.log('[Rifler] Webview script starting...');
         const scrollTop = groupContainer.scrollTop;
         const containerHeight = groupContainer.clientHeight || 150;
         const firstIdx = Math.max(0, Math.floor(scrollTop / MATCH_HEIGHT) - GROUP_OVERSCAN);
-        const lastIdx = Math.min(matches.length - 1, Math.ceil((scrollTop + containerHeight) / MATCH_HEIGHT) + GROUP_OVERSCAN);
+        const lastIdx = Math.min(matchIndexes.length - 1, Math.ceil((scrollTop + containerHeight) / MATCH_HEIGHT) + GROUP_OVERSCAN);
 
         // Build set of indices that should be visible
         const wantedIndices = new Set();
@@ -4194,19 +4348,21 @@ console.log('[Rifler] Webview script starting...');
 
         // Add or update visible elements
         for (let idx = firstIdx; idx <= lastIdx; idx++) {
-          const match = matches[idx];
+          const matchIndex = matchIndexes[idx];
+          const match = state.results[matchIndex];
+          if (!match) continue;
           const existingEl = existing.get(idx);
           if (existingEl) {
             // Update active state only
-            const isActive = match.originalIndex === state.activeIndex;
+            const isActive = matchIndex === state.activeIndex;
             existingEl.classList.toggle('active', isActive);
             continue;
           }
 
           const matchEl = document.createElement('div');
-          const isActive = match.originalIndex === state.activeIndex;
+          const isActive = matchIndex === state.activeIndex;
           matchEl.className = 'result-item' + (isActive ? ' active' : '');
-          matchEl.dataset.index = String(match.originalIndex);
+          matchEl.dataset.index = String(matchIndex);
           matchEl.dataset.localIndex = String(idx);
           matchEl.title = match.relativePath || match.fileName;
           matchEl.style.position = 'absolute';
@@ -4231,7 +4387,7 @@ console.log('[Rifler] Webview script starting...');
 
           matchEl.addEventListener('click', () => {
             // Single click selects/loads preview (no show/hide toggle)
-            if (match.originalIndex === state.activeIndex) {
+            if (matchIndex === state.activeIndex) {
               const active = state.results?.[state.activeIndex];
               if (active && (!state.fileContent || state.fileContent.uri !== active.uri)) {
                 loadFileContent(active);
@@ -4240,7 +4396,7 @@ console.log('[Rifler] Webview script starting...');
             }
             if (!state.groupScrollTops) state.groupScrollTops = {};
             state.groupScrollTops[itemData.path] = groupContainer.scrollTop;
-            setActiveIndex(match.originalIndex);
+            setActiveIndex(matchIndex);
           });
 
           matchEl.addEventListener('dblclick', () => {
@@ -4250,7 +4406,7 @@ console.log('[Rifler] Webview script starting...');
 
           matchEl.addEventListener('contextmenu', (e) => {
             e.preventDefault();
-            showContextMenu(e, match.originalIndex);
+            showContextMenu(e, matchIndex);
           });
 
           spacer.appendChild(matchEl);
@@ -4303,21 +4459,26 @@ console.log('[Rifler] Webview script starting...');
     }
 
     // Match row
+    const rowResult = state.results[itemData.originalIndex];
+    if (!rowResult) {
+      return item;
+    }
+
     const isActive = itemData.originalIndex === state.activeIndex;
     item.className = 'result-item' + (isActive ? ' active' : '');
     item.dataset.index = String(itemData.originalIndex);
-    item.title = itemData.relativePath || itemData.fileName;
+    item.title = rowResult.relativePath || rowResult.fileName;
 
-    const language = getLanguageFromFilename(itemData.fileName);
+    const language = getLanguageFromFilename(rowResult.fileName);
     const previewHtml = highlightMatchSafe(
-      itemData.preview,
-      itemData.previewMatchRanges || [itemData.previewMatchRange],
+      rowResult.preview,
+      rowResult.previewMatchRanges || [rowResult.previewMatchRange],
       language
     );
 
     item.innerHTML = 
       '<div class="result-meta">' +
-        '<span class="result-line-number">' + (itemData.line + 1) + '</span>' +
+        '<span class="result-line-number">' + (rowResult.line + 1) + '</span>' +
       '</div>' +
       '<div class="result-preview hljs">' + previewHtml + '</div>';
 
@@ -4536,9 +4697,7 @@ console.log('[Rifler] Webview script starting...');
       'swift': 'swift',
       'kt': 'kotlin'
     };
-    const lang = map[ext] || null;
-    console.log(`[Rifler] getLanguageFromFilename: ${fileName} -> ${lang}`);
-    return lang;
+    return map[ext] || null;
   }
 
   function ensureActiveVisible() {
@@ -4552,7 +4711,7 @@ console.log('[Rifler] Webview script starting...');
     if (renderIndex === -1) {
       renderIndex = state.renderItems.findIndex(item => 
         item.type === 'matchesGroup' && 
-        item.matches.some(m => m.originalIndex === state.activeIndex)
+        Array.isArray(item.matchIndexes) && item.matchIndexes.includes(state.activeIndex)
       );
     }
     
@@ -4665,7 +4824,9 @@ console.log('[Rifler] Webview script starting...');
       updateLocalMatches();
       updateHighlights();
     } else {
-      console.log('[Rifler] handleFileContent: rendering preview');
+      if (state.profilingEnabled) {
+        console.log('[Rifler] handleFileContent: rendering preview');
+      }
       // Ensure editor is hidden when in preview mode
       if (editorContainer) editorContainer.classList.remove('visible');
       if (previewContent) previewContent.style.display = 'block';
@@ -4869,15 +5030,24 @@ console.log('[Rifler] Webview script starting...');
     }
 
     const lines = fileData.content.split('\n');
+    const totalLines = lines.length;
 
-    console.log('[Rifler] renderFilePreview: Rendering', lines.length, 'lines. Total matches:', fileData.matches ? fileData.matches.length : 0);
-    console.log('[Rifler] Active line range:', activeLineStart, 'to', activeLineEnd, '(queryLineCount:', queryLineCount, 'queryHasNewlines:', queryHasNewlines, ')');
-    if (fileData.matches && fileData.matches.length > 0) {
-      console.log('[Rifler] Sample matches:', fileData.matches.slice(0, 5));
+    if (state.profilingEnabled) {
+      console.log('[Rifler] renderFilePreview: Rendering', totalLines, 'lines. Total matches:', fileData.matches ? fileData.matches.length : 0);
+      console.log('[Rifler] Active line range:', activeLineStart, 'to', activeLineEnd, '(queryLineCount:', queryLineCount, 'queryHasNewlines:', queryHasNewlines, ')');
+      if (fileData.matches && fileData.matches.length > 0) {
+        console.log('[Rifler] Sample matches:', fileData.matches.slice(0, 5));
+      }
     }
 
     const language = getLanguageFromFilename(fileData.fileName);
-    console.log('[Rifler] Detected language:', language);
+    if (state.profilingEnabled) {
+      console.log('[Rifler] Detected language:', language);
+    }
+
+    const windowState = getPreviewWindowForUri(fileData.uri, totalLines, activeLineStart, activeLineEnd);
+    const windowStart = windowState.start;
+    const windowEnd = windowState.end;
 
     const highlightSegment = (text) => {
       if (text === '') return '';
@@ -4949,7 +5119,12 @@ console.log('[Rifler] Webview script starting...');
     };
 
     let html = '';
-    lines.forEach((line, idx) => {
+    if (windowState.hasTopMore) {
+      html += '<div class="pv-window-hint" data-action="expand-up" style="padding:6px 10px; opacity:.75; font-size:12px; border-bottom:1px solid rgba(255,255,255,.08); cursor:pointer;">Show ' + windowStart + ' lines above...</div>';
+    }
+
+    for (let idx = windowStart; idx <= windowEnd; idx++) {
+      const line = lines[idx];
       const lineMatches = fileData.matches ? fileData.matches.filter(m => m.line === idx) : [];
       const hasMatch = lineMatches.length > 0;
       // For multiline matches, mark all lines in the active range as "active" (styling)
@@ -4957,7 +5132,7 @@ console.log('[Rifler] Webview script starting...');
       const isCurrentLine = idx >= activeLineStart && idx <= activeLineEnd;
 
       // Log lines in the active range to debug multiline active line behavior
-      if (idx >= activeLineStart && idx <= activeLineEnd) {
+      if (state.profilingEnabled && idx >= activeLineStart && idx <= activeLineEnd) {
         console.log('[Rifler] Active range line', idx, '- hasMatch:', hasMatch, 'isCurrentLine:', isCurrentLine, 'lineContent:', JSON.stringify(line.substring(0, 30)));
       }
 
@@ -4972,9 +5147,15 @@ console.log('[Rifler] Webview script starting...');
         '<div class="pvLineNo' + (hasMatch ? ' has-match' : '') + '">' + (idx + 1) + '</div>' +
         '<div class="pvCode hljs">' + lineContent + '</div>' +
       '</div>';
-    });
+    }
 
-    console.log('[Rifler] Generated HTML length:', html.length, 'lines:', lines.length);
+    if (windowState.hasBottomMore) {
+      html += '<div class="pv-window-hint" data-action="expand-down" style="padding:6px 10px; opacity:.75; font-size:12px; border-top:1px solid rgba(255,255,255,.08); cursor:pointer;">Show ' + (totalLines - windowEnd - 1) + ' more lines...</div>';
+    }
+
+    if (state.profilingEnabled) {
+      console.log('[Rifler] Generated HTML length:', html.length, 'windowLines:', (windowEnd - windowStart + 1), 'totalLines:', totalLines);
+    }
     
     // Ensure previewContent is visible and populated
     previewContent.innerHTML = html;
@@ -4986,6 +5167,7 @@ console.log('[Rifler] Webview script starting...');
     
     // Update cache markers to prevent duplicate renders
     previewContent.dataset.lastRenderedCacheKey = cacheKey;
+    previewContent.dataset.previewUri = fileData.uri || '';
     
     // Force a layout recalculation
     previewContent.offsetHeight; 
@@ -4993,7 +5175,9 @@ console.log('[Rifler] Webview script starting...');
     if (currentLine >= 0) {
       const currentLineEl = previewContent.querySelector('[data-line="' + currentLine + '"]');
       if (currentLineEl) {
-        console.log('[Rifler] Scrolling to line:', currentLine);
+        if (state.profilingEnabled) {
+          console.log('[Rifler] Scrolling to line:', currentLine);
+        }
         
         // Use scrollIntoView with a small timeout to ensure layout is ready
         setTimeout(() => {
@@ -5046,6 +5230,31 @@ console.log('[Rifler] Webview script starting...');
       query: query,
       options: state.options,
       activeIndex: state.activeIndex
+    });
+  }
+
+  if (previewContent) {
+    previewContent.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!target || !target.closest) return;
+      const hint = target.closest('.pv-window-hint');
+      if (!hint) return;
+      const action = hint.getAttribute('data-action');
+      const uri = previewContent.dataset.previewUri;
+      if (!uri) return;
+
+      const current = state.previewWindows && state.previewWindows[uri]
+        ? state.previewWindows[uri]
+        : { radius: 120 };
+      const nextRadius = action === 'expand-up' || action === 'expand-down'
+        ? current.radius * 2
+        : current.radius;
+
+      setPreviewWindowRadius(uri, nextRadius);
+      if (state.fileContent && state.fileContent.uri === uri) {
+        previewContent.dataset.lastRenderedCacheKey = '';
+        renderFilePreview(state.fileContent);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- add local search profiling with request IDs, phase timings, and stale-response protection to identify and avoid slow/late result updates
- reduce heavy UI/state overhead by sanitizing persisted state, slimming ripgrep payload previews, improving 10k-result rendering paths, and adding windowed preview rendering
- fix smart-exclude parity/count reporting by honoring enabled project excludes and reporting occurrence-based match counts to align with VS Code search behavior

## Validation
- npm run compile
- local profiling runs with broad query (`bb`) to compare count vs occurrences and verify sidebar/preview responsiveness